### PR TITLE
Add dialect-aware null sorting and BasePaginationDialect

### DIFF
--- a/.changeset/nulls-sort-support.md
+++ b/.changeset/nulls-sort-support.md
@@ -1,0 +1,5 @@
+---
+'kysely-cursor': minor
+---
+
+Add dialect-aware null sorting: optional `nulls: 'first' | 'last'` on sort items, `BasePaginationDialect` with `DialectMeta`, and null-safe keyset predicates that follow each engine's default NULL placement. Dialects are now classes (`new PostgresPaginationDialect()`). Cursor payloads include a version field; PostgreSQL no longer forces NULLS FIRST/LAST on every ORDER BY when `nulls` is omitted.

--- a/README.md
+++ b/README.md
@@ -141,17 +141,27 @@ Provide an ordered **sort set** that uniquely identifies rows:
 
 ```ts
 const sorts = [
-  { col: 'users.created_at', dir: 'desc', output: 'created_at' },
+  { col: 'users.created_at', dir: 'desc', output: 'created_at', nulls: 'last' },
   { col: 'users.id', dir: 'desc', output: 'id' }, // final non‑nullable & unique key
 ] as const
 ```
 
 - Leading sorts take precedence over later sorts.
-- Leading sorts may be nullable; the **final sort must be non‑nullable & unique**.
-- Use a primary key or a unique index for the final sort, this acts as a tie-breaker.
+- Leading sorts may be nullable; the **final sort must be non-nullable & unique**.
+- Use a primary key or a unique index for the final sort — this acts as a tie-breaker.
 - `dir` is the sort direction. Defaults to `asc`.
 - `col` is the field to sort by, optionally qualified.
 - `output` is the field name in your outputted rows. Defaults to `col`, without the qualifying prefix. May need to be explicitly set if your `col` is aliased in your select statement.
+- `nulls` is an optional per-sort null ordering hint:
+
+  ```ts
+  { col: 'users.deleted_at', dir: 'asc', nulls: 'last' }
+  ```
+
+  - `'first'` → place all `NULL`s before non-NULLs for that sort
+  - `'last'` → place all `NULL`s after non-NULLs for that sort
+  - If omitted, the dialect’s defaults are used (see below).
+  - On dialects that **don’t** support `NULLS FIRST / LAST` (e.g. MySQL, MSSQL), providing `nulls` will throw a `PaginationError` at runtime — so only specify it when the dialect can express it.
 
 ### Dialects
 
@@ -180,7 +190,7 @@ The default cursor codec is `codecPipe(superJsonCodec, base64UrlCodec)`.
 ### Null Sorting Behavior
 
 Handling of `NULL` values during sorting differs between database engines.
-To ensure consistent pagination behavior across dialects, this library **normalizes** null sorting rules.
+To ensure consistent pagination behavior across dialects, this library now supports **explicit** null ordering on each sort key (`nulls: 'first' | 'last'`) and falls back to dialect-aware defaults when it’s not provided.
 
 | Database System                  | Default NULLs (ASC) | Default NULLs (DESC) | Supports `NULLS FIRST / LAST`? |
 | -------------------------------- | ------------------- | -------------------- | ------------------------------ |
@@ -191,17 +201,23 @@ To ensure consistent pagination behavior across dialects, this library **normali
 
 #### Current behavior
 
-Because **PostgreSQL** is the _odd one out_ (sorting NULLs last on ascending by default),
-this library **inverts Postgres’s null ordering** to match the behaviour of the other supported dialects:
+1. **You can set it yourself**
+   On sorts where the column can be nullable, add:
 
-- Ascending (`ASC`) → `NULLS FIRST`
-- Descending (`DESC`) → `NULLS LAST`
+```ts
+const sort = { col: 'posts.published_at', dir: 'asc', nulls: 'last' }
+```
 
-This ensures consistent cursor pagination semantics across all engines, even when nullable sort keys are involved.
+If the dialect supports `NULLS FIRST / LAST` (Postgres, SQLite ≥ 3.30.0), this will be emitted as part of the `ORDER BY`. If it **doesn’t** (MySQL, MSSQL), the library throws a `PaginationError` with `code: 'INVALID_SORT'`, so you don’t silently get inconsistent pagination.
 
-#### Future plans
+2. **If you don’t set it, the dialect decides**
+   Each dialect declares:
+   - whether it supports explicit null directives
+   - what its default “ascending NULL placement” is
 
-In a future release, customizable null sorting behavior may be introduced for dialects that support `NULLS FIRST` / `NULLS LAST` natively (e.g. PostgreSQL, SQLite).
+   The paginator then:
+   - uses that default when `dir === 'asc'`
+   - uses the **inverted** default when `dir === 'desc'` (so if ASC puts NULLs first, DESC will put them last)
 
 ---
 
@@ -296,7 +312,7 @@ export type PaginatedResultWithEdges<T> = {
 
 ```ts
 const sorts = [
-  { col: 'posts.published_at', dir: 'desc', output: 'published_at' },
+  { col: 'posts.published_at', dir: 'desc', nulls: 'last', output: 'published_at' },
   { col: 'posts.id', dir: 'desc', output: 'id' },
 ] as const
 
@@ -395,7 +411,9 @@ The library over‑fetches by `limit+1` to determine if there’s another page. 
 forward; an empty result returns no tokens.
 
 **How are NULLs handled?**
-Ascending sorts treat NULLs first; descending sorts push NULLs last.
+You can now control this per sort via `nulls: 'first' | 'last'` on dialects that support it. If you omit it, the dialect’s
+declared defaults are used, and descending sorts get the inverse of the ascending default. On dialects that can’t express
+null placement, specifying `nulls` throws an error so you don’t get silent drift.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ const db = new Kysely<DB>({
 const cursorCodec = codecPipe(superJsonCodec, base64UrlCodec)
 
 const paginator = createPaginator({
-  dialect: PostgresPaginationDialect,
+  dialect: new PostgresPaginationDialect(),
   cursorCodec,
 })
 

--- a/examples/postgres/index.ts
+++ b/examples/postgres/index.ts
@@ -48,7 +48,7 @@ async function main() {
       await db.insertInto('users').values(rows).execute()
     }
 
-    const paginator = createPaginator({ dialect: PostgresPaginationDialect })
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
 
     const sorts = [
       { col: 'created_at', dir: 'desc' },

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -56,7 +56,13 @@ export const decodeCursor = async (cursor: CursorIncoming, keysetCodec: Codec<an
       type: 'prev',
       payload: await decodeCursorPayload(cursor.prevPage, keysetCodec),
     }
-  if ('offset' in cursor) return { type: 'offset', offset: cursor.offset }
+  if ('offset' in cursor) {
+    // offset is user input too: a negative/fractional offset would otherwise fall
+    // through to the driver and surface as an UNEXPECTED_ERROR instead of a 400
+    if (!Number.isInteger(cursor.offset) || cursor.offset < 0)
+      throw new PaginationError({ message: 'Invalid pagination offset', code: 'INVALID_TOKEN' })
+    return { type: 'offset', offset: cursor.offset }
+  }
 
   throw new PaginationError({ message: 'Invalid cursor', code: 'INVALID_TOKEN' })
 }

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -141,8 +141,13 @@ export const resolveEdges = async <O>(
 export const getSortOutput = (sort: SortItem<any, any, any, any>) =>
   'output' in sort ? sort.output : sort.col.split('.').at(-1)!
 
+/** Preimage fragment for omitted `nulls` — part of the cursor contract; do not change without bumping {@link CURSOR_VERSION}. */
+const NULLS_SIG_OMITTED = '-'
+
 export const sortSignature = (sorts: SortSet<any, any, any>) => {
-  const sig = sorts.map((s) => `${'output' in s ? s.output : s.col}:${s.dir ?? 'asc'}:${s.nulls}`).join('|')
+  const sig = sorts
+    .map((s) => `${'output' in s ? s.output : s.col}:${s.dir ?? 'asc'}:${s.nulls ?? NULLS_SIG_OMITTED}`)
+    .join('|')
   return createHash('sha256').update(sig).digest('hex').slice(0, 8)
 }
 

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -46,9 +46,9 @@ export const decodeCursor = async (cursor: CursorIncoming, keysetCodec: Codec<an
       type: 'prev',
       payload: await decodeCursorPayload(cursor.prevPage, keysetCodec),
     }
-  if ('offset' in cursor) return {type: 'offset', offset: cursor.offset}
+  if ('offset' in cursor) return { type: 'offset', offset: cursor.offset }
 
-  throw new PaginationError({message: 'Invalid cursor', code: 'INVALID_TOKEN'})
+  throw new PaginationError({ message: 'Invalid cursor', code: 'INVALID_TOKEN' })
 }
 
 const decodeCursorPayload = async (token: string, keysetCodec: Codec<any, string>) => {
@@ -99,7 +99,7 @@ export const resolveEdges = async <O>(
   return await Promise.all(
     rows.map(async (row) => {
       const cursor = await cursorCodec.encode(resolveCursor(row, sorts))
-      return {node: row, cursor}
+      return { node: row, cursor }
     }),
   )
 }
@@ -122,7 +122,7 @@ export const resolveCursor = (item: any, sorts: SortSet<any, any, any>) => {
     }),
   )
 
-  return {sig, k}
+  return { sig, k }
 }
 
 export const invertNulls = (nulls: NullsDirection) => {
@@ -137,7 +137,7 @@ export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends
   idx = 0,
 ): ExpressionWrapper<DB, TB, SqlBool> => {
   const sort = sorts[idx]
-  if (!sort) throw new PaginationError({message: 'Sort index out of bounds', code: 'UNEXPECTED_ERROR'})
+  if (!sort) throw new PaginationError({ message: 'Sort index out of bounds', code: 'UNEXPECTED_ERROR' })
 
   const dir = applyDefaultDirection(sort.dir)
   const col = sort.col as ReferenceExpression<DB, TB>
@@ -151,17 +151,14 @@ export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends
   // Determine the effective NULLS placement for this column given the direction.
   // If caller didn't specify, take dialect defaults (ASC default provided by meta, DESC gets the inverted one).
   const defaultAscNulls = meta.defaultNullsSortAsc // 'first' | 'last'
-  const nulls: NullsDirection =
-    sort.nulls ?? (dir === 'asc' ? defaultAscNulls : invertNulls(defaultAscNulls))
+  const nulls: NullsDirection = sort.nulls ?? (dir === 'asc' ? defaultAscNulls : invertNulls(defaultAscNulls))
 
   const value = decoded.k[key]
   const isLast = idx === sorts.length - 1
   const cmp = dir === 'desc' ? '<' : '>'
 
   // If there are more sort keys, build the recursive predicate for ties.
-  const next = !isLast
-    ? buildCursorPredicateRecursive(eb, sorts, decoded, meta, idx + 1)
-    : undefined
+  const next = !isLast ? buildCursorPredicateRecursive(eb, sorts, decoded, meta, idx + 1) : undefined
 
   // Helper to express an always-false condition in SQL without relying on literals.
   // (col IS NULL AND col IS NOT NULL) is guaranteed false and keeps us inside the builder API.
@@ -201,19 +198,14 @@ export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends
   // Base comparisons apply only to non-NULL candidates.
   // (We add NULL candidates depending on null placement.)
   const nonNullGreater = eb.and([eb(col, 'is not', null), eb(col, cmp, value)])
-  const nonNullTieThenNext = !isLast
-    ? eb.and([eb(col, 'is not', null), eb(col, '=', value), next!])
-    : undefined
+  const nonNullTieThenNext = !isLast ? eb.and([eb(col, 'is not', null), eb(col, '=', value), next!]) : undefined
 
   if (isLast) {
     // Last sort key: no recursion available.
     // After a non-NULL value:
     //   • non-NULL rows strictly greater (per dir)
     //   • plus NULLs if and only if NULLs are placed after non-NULLs at this position
-    return eb.or([
-      nonNullGreater,
-      ...(nulls === 'last' ? [eb(col, 'is', null)] : []),
-    ])
+    return eb.or([nonNullGreater, ...(nulls === 'last' ? [eb(col, 'is', null)] : [])])
   }
 
   // Not last: include the tie → next, and include NULLs when they are placed after non-NULLs.

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -125,7 +125,7 @@ export const resolveCursor = (item: any, sorts: SortSet<any, any, any>) => {
   return {sig, k}
 }
 
-const invertNulls = (nulls: NullsDirection) => {
+export const invertNulls = (nulls: NullsDirection) => {
   return nulls === 'first' ? 'last' : 'first'
 }
 

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -1,11 +1,12 @@
 import { createHash } from 'crypto'
-import type { ExpressionBuilder, ExpressionWrapper, ReferenceExpression, SelectQueryBuilder, SqlBool } from 'kysely'
+import type { ExpressionBuilder, ExpressionWrapper, ReferenceExpression, SqlBool } from 'kysely'
 import { z } from 'zod'
 
 import type { Codec } from './codec/codec.js'
 import { PaginationError } from './error.js'
-import type { SortItem, SortSet } from './sorting.js'
+import type { NullsDirection, SortItem, SortSet } from './sorting.js'
 import { applyDefaultDirection } from './sorting.js'
+import { DialectMeta } from '~/types.js'
 
 const CursorPayloadSchema = z.object({
   sig: z.string(),
@@ -45,9 +46,9 @@ export const decodeCursor = async (cursor: CursorIncoming, keysetCodec: Codec<an
       type: 'prev',
       payload: await decodeCursorPayload(cursor.prevPage, keysetCodec),
     }
-  if ('offset' in cursor) return { type: 'offset', offset: cursor.offset }
+  if ('offset' in cursor) return {type: 'offset', offset: cursor.offset}
 
-  throw new PaginationError({ message: 'Invalid cursor', code: 'INVALID_TOKEN' })
+  throw new PaginationError({message: 'Invalid cursor', code: 'INVALID_TOKEN'})
 }
 
 const decodeCursorPayload = async (token: string, keysetCodec: Codec<any, string>) => {
@@ -98,7 +99,7 @@ export const resolveEdges = async <O>(
   return await Promise.all(
     rows.map(async (row) => {
       const cursor = await cursorCodec.encode(resolveCursor(row, sorts))
-      return { node: row, cursor }
+      return {node: row, cursor}
     }),
   )
 }
@@ -107,7 +108,7 @@ export const getSortOutput = (sort: SortItem<any, any, any, any>) =>
   'output' in sort ? sort.output : sort.col.split('.').at(-1)!
 
 export const sortSignature = (sorts: SortSet<any, any, any>) => {
-  const sig = sorts.map((s) => `${'output' in s ? s.output : s.col}:${s.dir ?? 'asc'}`).join('|')
+  const sig = sorts.map((s) => `${'output' in s ? s.output : s.col}:${s.dir ?? 'asc'}:${s.nulls}`).join('|')
   return createHash('sha256').update(sig).digest('hex').slice(0, 8)
 }
 
@@ -121,17 +122,22 @@ export const resolveCursor = (item: any, sorts: SortSet<any, any, any>) => {
     }),
   )
 
-  return { sig, k }
+  return {sig, k}
+}
+
+const invertNulls = (nulls: NullsDirection) => {
+  return nulls === 'first' ? 'last' : 'first'
 }
 
 export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends SortSet<any, any, any>>(
   eb: ExpressionBuilder<DB, TB>,
   sorts: S,
   decoded: CursorPayload,
+  meta: DialectMeta,
   idx = 0,
 ): ExpressionWrapper<DB, TB, SqlBool> => {
   const sort = sorts[idx]
-  if (!sort) throw new PaginationError({ message: 'Sort index out of bounds', code: 'UNEXPECTED_ERROR' })
+  if (!sort) throw new PaginationError({message: 'Sort index out of bounds', code: 'UNEXPECTED_ERROR'})
 
   const dir = applyDefaultDirection(sort.dir)
   const col = sort.col as ReferenceExpression<DB, TB>
@@ -142,33 +148,78 @@ export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends
       code: 'INVALID_TOKEN',
     })
 
+  // Determine the effective NULLS placement for this column given the direction.
+  // If caller didn't specify, take dialect defaults (ASC default provided by meta, DESC gets the inverted one).
+  const defaultAscNulls = meta.defaultNullsSortAsc // 'first' | 'last'
+  const nulls: NullsDirection =
+    sort.nulls ?? (dir === 'asc' ? defaultAscNulls : invertNulls(defaultAscNulls))
+
   const value = decoded.k[key]
+  const isLast = idx === sorts.length - 1
   const cmp = dir === 'desc' ? '<' : '>'
 
-  if (idx === sorts.length - 1) {
-    // last sort: tie-breaker
-    return eb(col, cmp, value)
+  // If there are more sort keys, build the recursive predicate for ties.
+  const next = !isLast
+    ? buildCursorPredicateRecursive(eb, sorts, decoded, meta, idx + 1)
+    : undefined
+
+  // Helper to express an always-false condition in SQL without relying on literals.
+  // (col IS NULL AND col IS NOT NULL) is guaranteed false and keeps us inside the builder API.
+  const alwaysFalse = eb.and([eb(col, 'is', null), eb(col, 'is not', null)])
+
+  // ──────────────────────────────────────────────────────────────────────────────
+  // Cases where the cursor's current value is NULL
+  // ──────────────────────────────────────────────────────────────────────────────
+  if (value === null) {
+    if (nulls === 'first') {
+      // Order: NULLs block first, then non-NULLs.
+      // After a NULL cursor:
+      //   • Remaining NULLs that come after the cursor within the NULLs block (tie goes to `next`)
+      //   • All non-NULLs (they come after the NULL block)
+      if (isLast) {
+        // No `next` to break ties among NULLs. The only way to be "after" is to leave the NULL block.
+        return eb(col, 'is not', null)
+      }
+      return eb.or([eb.and([eb(col, 'is', null), next!]), eb(col, 'is not', null)])
+    } else {
+      // nulls === 'last'
+      // Order: non-NULLs first, then NULLs block.
+      // After a NULL cursor inside the trailing NULL block:
+      //   • Only remaining NULLs after this row (tie → `next`). There are no non-NULLs after.
+      if (isLast) {
+        // With no tie-breaker, there is nothing strictly after this NULL within the NULL block.
+        return alwaysFalse
+      }
+      return eb.and([eb(col, 'is', null), next!])
+    }
   }
 
-  // recursively build predicate for the next sort field
-  const next = buildCursorPredicateRecursive(eb, sorts, decoded, idx + 1)
+  // ──────────────────────────────────────────────────────────────────────────────
+  // Cursor value is NON-NULL
+  // ──────────────────────────────────────────────────────────────────────────────
 
-  if (value === null)
-    // handle NULLs explicitly since SQL ordering treats them specially
-    return dir === 'asc'
-      ? eb.or([eb(col, 'is', null).and(next), eb(col, 'is not', null)])
-      : eb.and([eb(col, 'is', null), next])
+  // Base comparisons apply only to non-NULL candidates.
+  // (We add NULL candidates depending on null placement.)
+  const nonNullGreater = eb.and([eb(col, 'is not', null), eb(col, cmp, value)])
+  const nonNullTieThenNext = !isLast
+    ? eb.and([eb(col, 'is not', null), eb(col, '=', value), next!])
+    : undefined
 
-  // combine current column comparison with recursion for tie-breaking
+  if (isLast) {
+    // Last sort key: no recursion available.
+    // After a non-NULL value:
+    //   • non-NULL rows strictly greater (per dir)
+    //   • plus NULLs if and only if NULLs are placed after non-NULLs at this position
+    return eb.or([
+      nonNullGreater,
+      ...(nulls === 'last' ? [eb(col, 'is', null)] : []),
+    ])
+  }
+
+  // Not last: include the tie → next, and include NULLs when they are placed after non-NULLs.
   return eb.or([
-    eb(col, cmp, value), // current column moves cursor forward
-    eb.and([eb(col, '=', value), next]), // tie on current col → check next one
-    ...(dir === 'desc' ? [eb(col, 'is', null)] : []), // include NULLs in DESC order
+    nonNullGreater, // advance on current column
+    nonNullTieThenNext!, // tie → look at the next column
+    ...(nulls === 'last' ? [eb(col, 'is', null)] : []), // when NULLs are after, they are also "after" the cursor
   ])
 }
-
-export const baseApplyCursor = <DB, TB extends keyof DB, O>(
-  builder: SelectQueryBuilder<DB, TB, O>,
-  sorts: SortSet<DB, TB, O>,
-  cursor: DecodedCursorNextPrev,
-) => builder.where((eb) => buildCursorPredicateRecursive(eb, sorts, cursor.payload))

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -2,13 +2,23 @@ import { createHash } from 'crypto'
 import type { ExpressionBuilder, ExpressionWrapper, ReferenceExpression, SqlBool } from 'kysely'
 import { z } from 'zod'
 
+import type { DialectMeta } from '~/types.js'
+
 import type { Codec } from './codec/codec.js'
 import { PaginationError } from './error.js'
 import type { NullsDirection, SortItem, SortSet } from './sorting.js'
 import { applyDefaultDirection } from './sorting.js'
-import { DialectMeta } from '~/types.js'
+
+/**
+ * Version of the cursor payload format.
+ * Bump this (and the schema literal) whenever the payload shape changes in a
+ * backwards-incompatible way, so old tokens fail loudly instead of silently
+ * mis-paginating.
+ */
+export const CURSOR_VERSION = 1 as const
 
 const CursorPayloadSchema = z.object({
+  v: z.literal(CURSOR_VERSION),
   sig: z.string(),
   k: z.record(z.string(), z.any()),
 })
@@ -52,8 +62,26 @@ export const decodeCursor = async (cursor: CursorIncoming, keysetCodec: Codec<an
 }
 
 const decodeCursorPayload = async (token: string, keysetCodec: Codec<any, string>) => {
-  const decoded = await keysetCodec.decode(token)
-  return CursorPayloadSchema.parse(decoded)
+  let decoded: unknown
+  try {
+    decoded = await keysetCodec.decode(token)
+  } catch (error) {
+    throw new PaginationError({ message: 'Invalid page token', code: 'INVALID_TOKEN', cause: error as Error })
+  }
+
+  const parsed = CursorPayloadSchema.safeParse(decoded)
+  if (!parsed.success) {
+    // a numeric but mismatched version means the token was minted by an incompatible
+    // version of this library — say so explicitly rather than reporting a generic failure
+    const version = (decoded as { v?: unknown } | null)?.v
+    const message =
+      typeof version === 'number' && version !== CURSOR_VERSION
+        ? `Unsupported cursor version: ${version}`
+        : 'Invalid page token'
+    throw new PaginationError({ message, code: 'INVALID_TOKEN', cause: parsed.error })
+  }
+
+  return parsed.data
 }
 
 export const resolvePageTokens = async (
@@ -122,7 +150,7 @@ export const resolveCursor = (item: any, sorts: SortSet<any, any, any>) => {
     }),
   )
 
-  return { sig, k }
+  return { v: CURSOR_VERSION, sig, k }
 }
 
 export const invertNulls = (nulls: NullsDirection) => {
@@ -157,15 +185,21 @@ export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends
   const isLast = idx === sorts.length - 1
   const cmp = dir === 'desc' ? '<' : '>'
 
+  // The final sort is required to be non-nullable & unique, so a NULL value here
+  // means the token is malformed or tampered with. Fail loudly rather than
+  // silently rewinding to the start of the result set.
+  if (isLast && value === null)
+    throw new PaginationError({
+      message: `Pagination cursor has null value for final sort "${key}"`,
+      code: 'INVALID_TOKEN',
+    })
+
   // If there are more sort keys, build the recursive predicate for ties.
   const next = !isLast ? buildCursorPredicateRecursive(eb, sorts, decoded, meta, idx + 1) : undefined
 
-  // Helper to express an always-false condition in SQL without relying on literals.
-  // (col IS NULL AND col IS NOT NULL) is guaranteed false and keeps us inside the builder API.
-  const alwaysFalse = eb.and([eb(col, 'is', null), eb(col, 'is not', null)])
-
   // ──────────────────────────────────────────────────────────────────────────────
   // Cases where the cursor's current value is NULL
+  // (never the last sort key — rejected above)
   // ──────────────────────────────────────────────────────────────────────────────
   if (value === null) {
     if (nulls === 'first') {
@@ -173,22 +207,13 @@ export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends
       // After a NULL cursor:
       //   • Remaining NULLs that come after the cursor within the NULLs block (tie goes to `next`)
       //   • All non-NULLs (they come after the NULL block)
-      if (isLast) {
-        // No `next` to break ties among NULLs. The only way to be "after" is to leave the NULL block.
-        return eb(col, 'is not', null)
-      }
       return eb.or([eb.and([eb(col, 'is', null), next!]), eb(col, 'is not', null)])
-    } else {
-      // nulls === 'last'
-      // Order: non-NULLs first, then NULLs block.
-      // After a NULL cursor inside the trailing NULL block:
-      //   • Only remaining NULLs after this row (tie → `next`). There are no non-NULLs after.
-      if (isLast) {
-        // With no tie-breaker, there is nothing strictly after this NULL within the NULL block.
-        return alwaysFalse
-      }
-      return eb.and([eb(col, 'is', null), next!])
     }
+    // nulls === 'last'
+    // Order: non-NULLs first, then NULLs block.
+    // After a NULL cursor inside the trailing NULL block:
+    //   • Only remaining NULLs after this row (tie → `next`). There are no non-NULLs after.
+    return eb.and([eb(col, 'is', null), next!])
   }
 
   // ──────────────────────────────────────────────────────────────────────────────

--- a/src/dialect/base.ts
+++ b/src/dialect/base.ts
@@ -1,8 +1,11 @@
-import { OrderByExpression, SelectQueryBuilder } from 'kysely'
-import { DialectMeta, PaginationDialect } from '../types.js'
-import { SortSet } from '../sorting.js'
-import { buildCursorPredicateRecursive, DecodedCursorNextPrev } from '../cursor.js'
+import type { OrderByExpression, SelectQueryBuilder } from 'kysely'
+
 import { PaginationError } from '~/error.js'
+
+import type { DecodedCursorNextPrev } from '../cursor.js'
+import { buildCursorPredicateRecursive } from '../cursor.js'
+import type { SortSet } from '../sorting.js'
+import type { DialectMeta, PaginationDialect } from '../types.js'
 
 export abstract class BasePaginationDialect implements PaginationDialect {
   abstract meta: DialectMeta

--- a/src/dialect/base.ts
+++ b/src/dialect/base.ts
@@ -1,0 +1,51 @@
+import { OrderByExpression, SelectQueryBuilder } from 'kysely'
+import { DialectMeta, PaginationDialect } from '../types.js'
+import { SortSet } from '../sorting.js'
+import { buildCursorPredicateRecursive, DecodedCursorNextPrev } from '../cursor.js'
+import { PaginationError } from '~/error.js'
+
+export abstract class BasePaginationDialect implements PaginationDialect {
+  abstract meta: DialectMeta
+
+  applyLimit<DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, limit: number): SelectQueryBuilder<DB, TB, O> {
+    return builder.limit(limit)
+  }
+
+  applyOffset<DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, offset: number): SelectQueryBuilder<DB, TB, O> {
+    return builder.offset(offset)
+  }
+
+  applySort<DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, sorts: SortSet<DB, TB, O>): SelectQueryBuilder<DB, TB, O> {
+    for (const s of sorts) {
+      const dir = s.dir ?? 'asc'
+
+      builder = builder.orderBy(s.col as OrderByExpression<DB, TB, O>, (a) => {
+        const sort = dir === 'desc' ? a.desc() : a.asc()
+
+        if (!s.nulls) return sort
+
+        if (!this.meta.supportsNullSortDirective) throw new PaginationError({
+          code: 'INVALID_SORT',
+          message: 'This dialect does not support nulls first/last',
+        })
+
+        switch (s.nulls) {
+          case 'first':
+            return sort.nullsFirst()
+          case 'last':
+            return sort.nullsLast()
+          default:
+            throw new PaginationError({
+              message: 'Unsupported nulls first/last', code: 'INVALID_SORT'
+            })
+        }
+      })
+    }
+
+    return builder as SelectQueryBuilder<DB, TB, O>
+  }
+
+  applyCursor<DB, TB extends keyof DB, O>(query: SelectQueryBuilder<DB, TB, O>, sorts: SortSet<DB, TB, O>, cursor: DecodedCursorNextPrev): SelectQueryBuilder<DB, TB, O> {
+    return query.where((eb) => buildCursorPredicateRecursive(eb, sorts, cursor.payload, this.meta))
+  }
+}

--- a/src/dialect/base.ts
+++ b/src/dialect/base.ts
@@ -7,15 +7,24 @@ import { PaginationError } from '~/error.js'
 export abstract class BasePaginationDialect implements PaginationDialect {
   abstract meta: DialectMeta
 
-  applyLimit<DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, limit: number): SelectQueryBuilder<DB, TB, O> {
+  applyLimit<DB, TB extends keyof DB, O>(
+    builder: SelectQueryBuilder<DB, TB, O>,
+    limit: number,
+  ): SelectQueryBuilder<DB, TB, O> {
     return builder.limit(limit)
   }
 
-  applyOffset<DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, offset: number): SelectQueryBuilder<DB, TB, O> {
+  applyOffset<DB, TB extends keyof DB, O>(
+    builder: SelectQueryBuilder<DB, TB, O>,
+    offset: number,
+  ): SelectQueryBuilder<DB, TB, O> {
     return builder.offset(offset)
   }
 
-  applySort<DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, sorts: SortSet<DB, TB, O>): SelectQueryBuilder<DB, TB, O> {
+  applySort<DB, TB extends keyof DB, O>(
+    builder: SelectQueryBuilder<DB, TB, O>,
+    sorts: SortSet<DB, TB, O>,
+  ): SelectQueryBuilder<DB, TB, O> {
     for (const s of sorts) {
       const dir = s.dir ?? 'asc'
 
@@ -24,10 +33,11 @@ export abstract class BasePaginationDialect implements PaginationDialect {
 
         if (!s.nulls) return sort
 
-        if (!this.meta.supportsNullSortDirective) throw new PaginationError({
-          code: 'INVALID_SORT',
-          message: 'This dialect does not support nulls first/last',
-        })
+        if (!this.meta.supportsNullSortDirective)
+          throw new PaginationError({
+            code: 'INVALID_SORT',
+            message: 'This dialect does not support nulls first/last',
+          })
 
         switch (s.nulls) {
           case 'first':
@@ -46,7 +56,11 @@ export abstract class BasePaginationDialect implements PaginationDialect {
     return builder as SelectQueryBuilder<DB, TB, O>
   }
 
-  applyCursor<DB, TB extends keyof DB, O>(query: SelectQueryBuilder<DB, TB, O>, sorts: SortSet<DB, TB, O>, cursor: DecodedCursorNextPrev): SelectQueryBuilder<DB, TB, O> {
+  applyCursor<DB, TB extends keyof DB, O>(
+    query: SelectQueryBuilder<DB, TB, O>,
+    sorts: SortSet<DB, TB, O>,
+    cursor: DecodedCursorNextPrev,
+  ): SelectQueryBuilder<DB, TB, O> {
     return query.where((eb) => buildCursorPredicateRecursive(eb, sorts, cursor.payload, this.meta))
   }
 }

--- a/src/dialect/base.ts
+++ b/src/dialect/base.ts
@@ -36,7 +36,8 @@ export abstract class BasePaginationDialect implements PaginationDialect {
             return sort.nullsLast()
           default:
             throw new PaginationError({
-              message: 'Unsupported nulls first/last', code: 'INVALID_SORT'
+              message: 'Unsupported nulls first/last',
+              code: 'INVALID_SORT',
             })
         }
       })

--- a/src/dialect/mssql.ts
+++ b/src/dialect/mssql.ts
@@ -1,26 +1,16 @@
-import type { OrderByExpression, SelectQueryBuilder } from 'kysely'
-
-import { baseApplyCursor } from '../cursor.js'
-import type { SortSet } from '../sorting.js'
-import type { PaginationDialect } from '../types.js'
+import type { SelectQueryBuilder } from 'kysely'
+import { BasePaginationDialect } from '~/dialect/base.js'
 
 /**
  * A dialect for SQL Server
  */
-export const MssqlPaginationDialect: PaginationDialect = {
-  applyLimit: (builder, limit, cursorType) => (cursorType === 'offset' ? builder.fetch(limit) : builder.top(limit)),
+export class MssqlPaginationDialect extends BasePaginationDialect {
+  meta = {
+    supportsNullSortDirective: false,
+    defaultNullsSortAsc: 'first' as const,
+  }
 
-  applyOffset: (builder, offset) => builder.offset(offset),
-
-  applySort: <DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, sorts: SortSet<DB, TB, O>) => {
-    for (const s of sorts) {
-      const dir = s.dir ?? 'asc'
-
-      builder = builder.orderBy(s.col as OrderByExpression<DB, TB, O>, dir)
-    }
-
-    return builder
-  },
-
-  applyCursor: baseApplyCursor,
+  override applyLimit<DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, limit: number, cursorType?: 'next' | 'prev' | 'offset'): SelectQueryBuilder<DB, TB, O> {
+    return cursorType === 'offset' ? builder.fetch(limit) : builder.top(limit)
+  }
 }

--- a/src/dialect/mssql.ts
+++ b/src/dialect/mssql.ts
@@ -10,7 +10,11 @@ export class MssqlPaginationDialect extends BasePaginationDialect {
     defaultNullsSortAsc: 'first' as const,
   }
 
-  override applyLimit<DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, limit: number, cursorType?: 'next' | 'prev' | 'offset'): SelectQueryBuilder<DB, TB, O> {
+  override applyLimit<DB, TB extends keyof DB, O>(
+    builder: SelectQueryBuilder<DB, TB, O>,
+    limit: number,
+    cursorType?: 'next' | 'prev' | 'offset',
+  ): SelectQueryBuilder<DB, TB, O> {
     return cursorType === 'offset' ? builder.fetch(limit) : builder.top(limit)
   }
 }

--- a/src/dialect/mssql.ts
+++ b/src/dialect/mssql.ts
@@ -1,4 +1,5 @@
 import type { SelectQueryBuilder } from 'kysely'
+
 import { BasePaginationDialect } from '~/dialect/base.js'
 
 /**

--- a/src/dialect/mysql.ts
+++ b/src/dialect/mysql.ts
@@ -6,6 +6,6 @@ import { BasePaginationDialect } from '~/dialect/base.js'
 export class MysqlPaginationDialect extends BasePaginationDialect {
   meta = {
     supportsNullSortDirective: false,
-    defaultNullsSortAsc: 'first' as const
+    defaultNullsSortAsc: 'first' as const,
   }
 }

--- a/src/dialect/mysql.ts
+++ b/src/dialect/mysql.ts
@@ -1,26 +1,11 @@
-import type { OrderByExpression, SelectQueryBuilder } from 'kysely'
-
-import { baseApplyCursor } from '../cursor.js'
-import type { SortSet } from '../sorting.js'
-import type { PaginationDialect } from '../types.js'
+import { BasePaginationDialect } from '~/dialect/base.js'
 
 /**
  * A dialect for MySQL
  */
-export const MysqlPaginationDialect: PaginationDialect = {
-  applyLimit: (builder, limit) => builder.limit(limit),
-
-  applyOffset: (builder, offset) => builder.offset(offset),
-
-  applySort: <DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, sorts: SortSet<DB, TB, O>) => {
-    for (const s of sorts) {
-      const dir = s.dir ?? 'asc'
-
-      builder = builder.orderBy(s.col as OrderByExpression<DB, TB, O>, dir)
-    }
-
-    return builder
-  },
-
-  applyCursor: baseApplyCursor,
+export class MysqlPaginationDialect extends BasePaginationDialect {
+  meta = {
+    supportsNullSortDirective: false,
+    defaultNullsSortAsc: 'first' as const
+  }
 }

--- a/src/dialect/postgres.ts
+++ b/src/dialect/postgres.ts
@@ -1,28 +1,11 @@
-import type { OrderByExpression, SelectQueryBuilder } from 'kysely'
-
-import { baseApplyCursor } from '../cursor.js'
-import type { SortSet } from '../sorting.js'
-import type { PaginationDialect } from '../types.js'
+import { BasePaginationDialect } from '~/dialect/base.js'
 
 /**
  * A dialect for PostgreSQL
  */
-export const PostgresPaginationDialect: PaginationDialect = {
-  applyLimit: (builder, limit) => builder.limit(limit),
-
-  applyOffset: (builder, offset) => builder.offset(offset),
-
-  applySort: <DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, sorts: SortSet<DB, TB, O>) => {
-    for (const s of sorts) {
-      const dir = s.dir ?? 'asc'
-
-      builder = builder.orderBy(s.col as OrderByExpression<DB, TB, O>, (a) =>
-        dir === 'asc' ? a.asc().nullsFirst() : a.desc().nullsLast(),
-      )
-    }
-
-    return builder
-  },
-
-  applyCursor: baseApplyCursor,
+export class PostgresPaginationDialect extends BasePaginationDialect {
+  meta = {
+    supportsNullSortDirective: true,
+    defaultNullsSortAsc: 'last' as const,
+  }
 }

--- a/src/dialect/sqlite.ts
+++ b/src/dialect/sqlite.ts
@@ -1,26 +1,11 @@
-import type { OrderByExpression, SelectQueryBuilder } from 'kysely'
-
-import { baseApplyCursor } from '../cursor.js'
-import type { SortSet } from '../sorting.js'
-import type { PaginationDialect } from '../types.js'
+import { BasePaginationDialect } from '~/dialect/base.js'
 
 /**
  * A dialect for SQLite
  */
-export const SqlitePaginationDialect: PaginationDialect = {
-  applyLimit: (builder, limit) => builder.limit(limit),
-
-  applyOffset: (builder, offset) => builder.offset(offset),
-
-  applySort: <DB, TB extends keyof DB, O>(builder: SelectQueryBuilder<DB, TB, O>, sorts: SortSet<DB, TB, O>) => {
-    for (const s of sorts) {
-      const dir = s.dir ?? 'asc'
-
-      builder = builder.orderBy(s.col as OrderByExpression<DB, TB, O>, dir)
-    }
-
-    return builder
-  },
-
-  applyCursor: baseApplyCursor,
+export class SqlitePaginationDialect extends BasePaginationDialect {
+  meta = {
+    supportsNullSortDirective: true,
+    defaultNullsSortAsc: 'first' as const
+  }
 }

--- a/src/dialect/sqlite.ts
+++ b/src/dialect/sqlite.ts
@@ -6,6 +6,6 @@ import { BasePaginationDialect } from '~/dialect/base.js'
 export class SqlitePaginationDialect extends BasePaginationDialect {
   meta = {
     supportsNullSortDirective: true,
-    defaultNullsSortAsc: 'first' as const
+    defaultNullsSortAsc: 'first' as const,
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export { buildCursorPredicateRecursive, CursorIncoming, EdgeOutgoing } from './c
 export { ErrorCode, PaginationError } from './error.js'
 
 // paginator
-export { createPaginator, paginateWithEdges, paginate } from './paginator.js'
+export { createPaginator, paginate, paginateWithEdges } from './paginator.js'
 export type {
   PaginateArgs,
   PaginatedResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,13 +13,13 @@ export { PostgresPaginationDialect } from './dialect/postgres.js'
 export { SqlitePaginationDialect } from './dialect/sqlite.js'
 
 // cursor
-export { baseApplyCursor, buildCursorPredicateRecursive, CursorIncoming, EdgeOutgoing } from './cursor.js'
+export { buildCursorPredicateRecursive, CursorIncoming, EdgeOutgoing } from './cursor.js'
 
 // error
 export { ErrorCode, PaginationError } from './error.js'
 
 // paginator
-export { createPaginator, paginateWithEdges } from './paginator.js'
+export { createPaginator, paginateWithEdges, paginate } from './paginator.js'
 export type {
   PaginateArgs,
   PaginatedResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { stashCodec } from './codec/stash.js'
 export { superJsonCodec } from './codec/superJson.js'
 
 // dialects
+export { BasePaginationDialect } from './dialect/base.js'
 export { MssqlPaginationDialect } from './dialect/mssql.js'
 export { MysqlPaginationDialect } from './dialect/mysql.js'
 export { PostgresPaginationDialect } from './dialect/postgres.js'

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -14,7 +14,7 @@ export const createPaginator = (opts: PaginatorOptions): Paginator => ({
   paginateWithEdges: (args) => paginateWithEdges({ ...args, ...opts }),
 })
 
-export const paginate = async <DB, TB extends keyof DB, O, S extends SortSet<DB, TB, O>>({
+export const paginate = async <DB, TB extends keyof DB,O, S extends SortSet<DB, TB, O>>({
   query,
   sorts,
   limit,
@@ -70,7 +70,7 @@ export const paginate = async <DB, TB extends keyof DB, O, S extends SortSet<DB,
   }
 }
 
-export const paginateWithEdges = async <DB, TB extends keyof DB, O, S extends SortSet<DB, TB, O>>(
+export const paginateWithEdges = async <DB, TB extends keyof DB,O, S extends SortSet<DB, TB, O>>(
   args: PaginateArgs<DB, TB, O, S> & PaginatorOptions,
 ): Promise<PaginatedResultWithEdges<O>> => {
   const { sorts, cursorCodec = DEFAULT_CURSOR_CODEC } = args

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -1,7 +1,7 @@
 import { base64UrlCodec } from './codec/base64Url.js'
 import { codecPipe } from './codec/codec.js'
 import { superJsonCodec } from './codec/superJson.js'
-import { decodeCursor, resolveEdges, resolvePageTokens, sortSignature } from './cursor.js'
+import { decodeCursor, invertNulls, resolveEdges, resolvePageTokens, sortSignature } from './cursor.js'
 import { PaginationError } from './error.js'
 import type { SortSet } from './sorting.js'
 import { applyDefaultDirection } from './sorting.js'
@@ -100,4 +100,8 @@ const invertSorts = <S extends SortSet<any, any, any>>(sorts: S): S =>
   sorts.map((s) => ({
     ...s,
     dir: applyDefaultDirection(s.dir) === 'desc' ? 'asc' : 'desc',
+    // explicit null placement must also flip so the inverted ORDER BY is the exact
+    // reverse of the forward order (e.g. ASC NULLS LAST reverses to DESC NULLS FIRST).
+    // when unset, placement is derived from the (inverted) direction, so leave it undefined.
+    nulls: s.nulls ? invertNulls(s.nulls) : undefined,
   })) as unknown as S

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -14,7 +14,7 @@ export const createPaginator = (opts: PaginatorOptions): Paginator => ({
   paginateWithEdges: (args) => paginateWithEdges({ ...args, ...opts }),
 })
 
-export const paginate = async <DB, TB extends keyof DB,O, S extends SortSet<DB, TB, O>>({
+export const paginate = async <DB, TB extends keyof DB, O, S extends SortSet<DB, TB, O>>({
   query,
   sorts,
   limit,
@@ -70,7 +70,7 @@ export const paginate = async <DB, TB extends keyof DB,O, S extends SortSet<DB, 
   }
 }
 
-export const paginateWithEdges = async <DB, TB extends keyof DB,O, S extends SortSet<DB, TB, O>>(
+export const paginateWithEdges = async <DB, TB extends keyof DB, O, S extends SortSet<DB, TB, O>>(
   args: PaginateArgs<DB, TB, O, S> & PaginatorOptions,
 ): Promise<PaginatedResultWithEdges<O>> => {
   const { sorts, cursorCodec = DEFAULT_CURSOR_CODEC } = args

--- a/src/sorting.ts
+++ b/src/sorting.ts
@@ -13,8 +13,11 @@ type OptionallyQualified<TB, O, Allowed> = TB extends string
 
 export const applyDefaultDirection = (dir: OrderByDirection | undefined | null): OrderByDirection => dir ?? 'asc'
 
-export type SortItem<DB, TB extends keyof DB, O, Allowed> = {
+export type NullsDirection = 'first' | 'last'
+
+export type SortItem<DB, TB extends keyof DB,O, Allowed> = {
   dir?: OrderByDirection
+  nulls?: NullsDirection
 } & (
   | {
       col: ReferenceExpression<DB, TB>
@@ -27,7 +30,7 @@ export type SortItem<DB, TB extends keyof DB, O, Allowed> = {
 
 type Sortable = string | number | boolean | Date | bigint
 
-export type SortSet<DB, TB extends keyof DB, O> = readonly [
+export type SortSet<DB, TB extends keyof DB,O> = readonly [
   ...SortItem<DB, TB, O, Sortable | null>[], // nullable leading sorts
   SortItem<DB, TB, O, Sortable>, // non-null final sort
 ]

--- a/src/sorting.ts
+++ b/src/sorting.ts
@@ -15,9 +15,9 @@ export const applyDefaultDirection = (dir: OrderByDirection | undefined | null):
 
 export type NullsDirection = 'first' | 'last'
 
-export type SortItem<DB, TB extends keyof DB,O, Allowed> = {
+export type SortItem<DB, TB extends keyof DB, O, Allowed> = {
   dir?: OrderByDirection
-  nulls?: NullsDirection
+  nulls?: null extends Allowed ? NullsDirection : undefined
 } & (
   | {
       col: ReferenceExpression<DB, TB>
@@ -30,7 +30,7 @@ export type SortItem<DB, TB extends keyof DB,O, Allowed> = {
 
 type Sortable = string | number | boolean | Date | bigint
 
-export type SortSet<DB, TB extends keyof DB,O> = readonly [
+export type SortSet<DB, TB extends keyof DB, O> = readonly [
   ...SortItem<DB, TB, O, Sortable | null>[], // nullable leading sorts
   SortItem<DB, TB, O, Sortable>, // non-null final sort
 ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,11 +2,11 @@ import type { SelectQueryBuilder } from 'kysely'
 
 import type { Codec } from './codec/codec.js'
 import type { CursorIncoming, CursorOutgoing, DecodedCursorNextPrev, EdgeOutgoing } from './cursor.js'
-import type { SortSet } from './sorting.js'
+import { NullsDirection, SortSet } from './sorting.js'
 
 export type DialectMeta = {
   supportsNullSortDirective: boolean
-  defaultNullsSortAsc: 'first' | 'last'
+  defaultNullsSortAsc: NullsDirection
 }
 
 export type PaginationDialect = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,20 +4,30 @@ import type { Codec } from './codec/codec.js'
 import type { CursorIncoming, CursorOutgoing, DecodedCursorNextPrev, EdgeOutgoing } from './cursor.js'
 import type { SortSet } from './sorting.js'
 
+export type DialectMeta = {
+  supportsNullSortDirective: boolean
+  defaultNullsSortAsc: 'first' | 'last'
+}
+
 export type PaginationDialect = {
+  meta: DialectMeta
+
   applyLimit: <DB, TB extends keyof DB, O>(
     builder: SelectQueryBuilder<DB, TB, O>,
     limit: number,
     cursorType?: 'next' | 'prev' | 'offset',
   ) => SelectQueryBuilder<DB, TB, O>
+
   applyOffset: <DB, TB extends keyof DB, O>(
     builder: SelectQueryBuilder<DB, TB, O>,
     offset: number,
   ) => SelectQueryBuilder<DB, TB, O>
+
   applySort: <DB, TB extends keyof DB, O>(
     builder: SelectQueryBuilder<DB, TB, O>,
     sorts: SortSet<DB, TB, O>,
   ) => SelectQueryBuilder<DB, TB, O>
+
   applyCursor: <DB, TB extends keyof DB, O>(
     query: SelectQueryBuilder<DB, TB, O>,
     sorts: SortSet<DB, TB, O>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type { SelectQueryBuilder } from 'kysely'
 
 import type { Codec } from './codec/codec.js'
 import type { CursorIncoming, CursorOutgoing, DecodedCursorNextPrev, EdgeOutgoing } from './cursor.js'
-import { NullsDirection, SortSet } from './sorting.js'
+import type { NullsDirection, SortSet } from './sorting.js'
 
 export type DialectMeta = {
   supportsNullSortDirective: boolean

--- a/test/dialect/mssql.test.ts
+++ b/test/dialect/mssql.test.ts
@@ -86,5 +86,5 @@ describe('MSSQL pagination helper', () => {
     await mssql?.stop().catch(() => {})
   })
 
-  runSharedTests(() => createTestHelpers(db, config), 'mssql')
+  runSharedTests(() => createTestHelpers(db, config), 'mssql', config.dialect.meta)
 })

--- a/test/dialect/mssql.test.ts
+++ b/test/dialect/mssql.test.ts
@@ -14,7 +14,7 @@ describe('MSSQL pagination helper', () => {
   let db: Kysely<TestDB>
 
   const config: DatabaseConfig = {
-    dialect: MssqlPaginationDialect,
+    dialect: new MssqlPaginationDialect(),
     createTable: async (db) => {
       await sql`
         CREATE TABLE users (

--- a/test/dialect/mssql.test.ts
+++ b/test/dialect/mssql.test.ts
@@ -29,14 +29,6 @@ describe('MSSQL pagination helper', () => {
     insertTestData: async (db, rows) => {
       await db.insertInto('users').values(rows).execute()
     },
-    applySortToQuery: (query, sorts) => {
-      for (const s of sorts) {
-        const dir = s.dir ?? 'asc'
-        // MSSQL's default NULLS behavior: NULLS FIRST for ASC, NULLS LAST for DESC
-        query = query.orderBy(s.col as any, dir)
-      }
-      return query
-    },
   }
 
   beforeAll(async () => {

--- a/test/dialect/mysql.test.ts
+++ b/test/dialect/mysql.test.ts
@@ -84,5 +84,5 @@ describe('MySQL pagination helper', () => {
     await mysqlC?.stop().catch(() => {})
   })
 
-  runSharedTests(() => createTestHelpers(db, config), 'mysql')
+  runSharedTests(() => createTestHelpers(db, config), 'mysql', config.dialect.meta)
 })

--- a/test/dialect/mysql.test.ts
+++ b/test/dialect/mysql.test.ts
@@ -29,14 +29,6 @@ describe('MySQL pagination helper', () => {
     insertTestData: async (db, rows) => {
       await db.insertInto('users').values(rows).execute()
     },
-    applySortToQuery: (query, sorts) => {
-      for (const s of sorts) {
-        const dir = s.dir ?? 'asc'
-        // MSSQL's default NULLS behavior: NULLS FIRST for ASC, NULLS LAST for DESC
-        query = query.orderBy(s.col as any, dir)
-      }
-      return query
-    },
   }
 
   beforeAll(async () => {

--- a/test/dialect/mysql.test.ts
+++ b/test/dialect/mysql.test.ts
@@ -14,7 +14,7 @@ describe('MySQL pagination helper', () => {
   let pool: mysql.Pool
 
   const config: DatabaseConfig = {
-    dialect: MysqlPaginationDialect,
+    dialect: new MysqlPaginationDialect(),
     createTable: async (db) => {
       await sql`
         CREATE TABLE users (

--- a/test/dialect/postgres.test.ts
+++ b/test/dialect/postgres.test.ts
@@ -14,7 +14,7 @@ describe('PostgreSQL pagination helper', () => {
   let db: Kysely<TestDB>
 
   const config: DatabaseConfig = {
-    dialect: PostgresPaginationDialect,
+    dialect: new PostgresPaginationDialect(),
     createTable: async (db) => {
       await db.schema
         .createTable('users')

--- a/test/dialect/postgres.test.ts
+++ b/test/dialect/postgres.test.ts
@@ -28,20 +28,6 @@ describe('PostgreSQL pagination helper', () => {
     insertTestData: async (db, rows) => {
       await db.insertInto('users').values(rows).execute()
     },
-    applySortToQuery: (query, sorts) => {
-      for (const s of sorts) {
-        const dir = s.dir ?? 'asc'
-        query = query.orderBy(s.col, (o: any) => {
-          const base = dir === 'asc' ? o.asc() : o.desc()
-
-          if (s.nulls === 'first') return base.nullsFirst()
-          if (s.nulls === 'last') return base.nullsLast()
-
-          return dir === 'asc' ? base.nullsLast() : base.nullsFirst()
-        })
-      }
-      return query
-    },
   }
 
   beforeAll(async () => {

--- a/test/dialect/postgres.test.ts
+++ b/test/dialect/postgres.test.ts
@@ -31,8 +31,14 @@ describe('PostgreSQL pagination helper', () => {
     applySortToQuery: (query, sorts) => {
       for (const s of sorts) {
         const dir = s.dir ?? 'asc'
-        // Reproduce PostgresStrategy's NULLS behavior for parity with MSSQL
-        query = query.orderBy(s.col, (o: any) => (dir === 'asc' ? o.asc().nullsFirst() : o.desc().nullsLast()))
+        query = query.orderBy(s.col, (o: any) => {
+          const base = dir === 'asc' ? o.asc() : o.desc()
+
+          if (s.nulls === 'first') return base.nullsFirst()
+          if (s.nulls === 'last') return base.nullsLast()
+
+          return dir === 'asc' ? base.nullsLast() : base.nullsFirst()
+        })
       }
       return query
     },
@@ -58,5 +64,5 @@ describe('PostgreSQL pagination helper', () => {
     await pg?.stop().catch(() => {})
   })
 
-  runSharedTests(() => createTestHelpers(db, config), 'postgres')
+  runSharedTests(() => createTestHelpers(db, config), 'postgres', config.dialect.meta)
 })

--- a/test/dialect/shared.ts
+++ b/test/dialect/shared.ts
@@ -6,8 +6,8 @@ import { superJsonCodec } from '~/codec/superJson.js'
 import { invertNulls, resolveCursor } from '~/cursor.js'
 import type { PaginatedResult } from '~/index.js'
 import { createPaginator } from '~/index.js'
-import { NullsDirection, SortSet } from '~/sorting.js'
-import { DialectMeta, PaginationDialect } from '~/types.js'
+import type { NullsDirection, SortSet } from '~/sorting.js'
+import type { DialectMeta, PaginationDialect } from '~/types.js'
 
 export interface UsersTable {
   id: Generated<number>
@@ -291,13 +291,179 @@ export const runSharedTests = (
     }
   })
 
+  // regression: walking backward must replay forward pages even when a page boundary
+  // falls inside (or next to) the NULL block
+  it('walks backward across a NULL boundary with dialect-default null placement', async () => {
+    const { baseBuilder, paginator, page } = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      { col: 'users.rating', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    const limit = 4
+    const first = await page(limit, sorts)
+    const second = await page(limit, sorts, first.nextPage)
+    const third = await page(limit, sorts, second.nextPage)
+
+    expect(third.prevPage).toBeTruthy()
+
+    // step back twice: at least one of these hops crosses the NULL boundary
+    // regardless of where this dialect places NULLs for ASC
+    const backOne = await paginator.paginate({
+      query: baseBuilder(),
+      sorts,
+      limit,
+      cursor: { prevPage: third.prevPage! },
+    })
+    expect(backOne.items.map((r) => r.id)).toEqual(second.items.map((r) => r.id))
+
+    expect(backOne.prevPage).toBeTruthy()
+    const backTwo = await paginator.paginate({
+      query: baseBuilder(),
+      sorts,
+      limit,
+      cursor: { prevPage: backOne.prevPage! },
+    })
+    expect(backTwo.items.map((r) => r.id)).toEqual(first.items.map((r) => r.id))
+
+    // and going forward again returns the same pages
+    const forwardAgain = await paginator.paginate({
+      query: baseBuilder(),
+      sorts,
+      limit,
+      cursor: { nextPage: backTwo.nextPage! },
+    })
+    expect(forwardAgain.items.map((r) => r.id)).toEqual(second.items.map((r) => r.id))
+  })
+
+  // same as above, but with an explicit nulls directive — the inverted (backward) query
+  // must flip the directive too, otherwise the backward order is not the reverse of the
+  // forward order and pages come back wrong across the NULL boundary
+  const itSupportsNulls = meta.supportsNullSortDirective ? it : it.skip
+  itSupportsNulls('walks backward across a NULL boundary with an explicit nulls directive', async () => {
+    const { baseBuilder, paginator, page } = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      { col: 'users.rating', dir: 'asc', nulls: 'last' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    // with NULLS LAST the final page starts inside the NULL block, so stepping back
+    // from it must cross the NULL → non-NULL boundary
+    const limit = 4
+    const first = await page(limit, sorts)
+    const second = await page(limit, sorts, first.nextPage)
+    const third = await page(limit, sorts, second.nextPage)
+    const fourth = await page(limit, sorts, third.nextPage)
+
+    expect(fourth.items.length).toBeGreaterThan(0)
+    expect(fourth.items[0]!.rating).toBeNull()
+
+    const backOne = await paginator.paginate({
+      query: baseBuilder(),
+      sorts,
+      limit,
+      cursor: { prevPage: fourth.prevPage! },
+    })
+    expect(backOne.items.map((r) => r.id)).toEqual(third.items.map((r) => r.id))
+
+    const backTwo = await paginator.paginate({
+      query: baseBuilder(),
+      sorts,
+      limit,
+      cursor: { prevPage: backOne.prevPage! },
+    })
+    expect(backTwo.items.map((r) => r.id)).toEqual(second.items.map((r) => r.id))
+  })
+
+  // property: for any sort set and page size, paginating all the way forward and then
+  // all the way back must replay the exact same pages in reverse order
+  it('round-trips: forward then backward pagination replays identical pages', async () => {
+    const { baseBuilder, paginator } = createHelpers()
+
+    const sortVariants: SortSet<TestDB, 'users', TestRow>[] = [
+      // non-nullable baseline
+      [
+        { col: 'users.created_at', dir: 'asc' },
+        { col: 'users.id', dir: 'asc' },
+      ],
+      // nullable leading sort, dialect-default placement
+      [
+        { col: 'users.rating', dir: 'asc' },
+        { col: 'users.id', dir: 'asc' },
+      ],
+      [
+        { col: 'users.rating', dir: 'desc' },
+        { col: 'users.id', dir: 'asc' },
+      ],
+    ]
+
+    if (meta.supportsNullSortDirective) {
+      sortVariants.push(
+        [
+          { col: 'users.rating', dir: 'asc', nulls: 'first' },
+          { col: 'users.id', dir: 'asc' },
+        ],
+        [
+          { col: 'users.rating', dir: 'asc', nulls: 'last' },
+          { col: 'users.id', dir: 'desc' },
+        ],
+        [
+          { col: 'users.rating', dir: 'desc', nulls: 'first' },
+          { col: 'users.id', dir: 'asc' },
+        ],
+      )
+    }
+
+    const ids = (pages: TestRow[][]) => pages.map((p) => p.map((r) => r.id))
+
+    for (const sorts of sortVariants) {
+      for (const limit of [1, 2, 3, 5]) {
+        // walk forward through every page
+        const forwardPages: TestRow[][] = []
+        let nextToken: string | undefined
+        let lastPrevToken: string | undefined
+        do {
+          const res = await paginator.paginate({
+            query: baseBuilder(),
+            sorts,
+            limit,
+            cursor: nextToken ? { nextPage: nextToken } : undefined,
+          })
+          forwardPages.push(res.items)
+          nextToken = res.nextPage
+          lastPrevToken = res.prevPage
+        } while (nextToken)
+
+        // walk all the way back from the last page
+        const backwardPages: TestRow[][] = []
+        let prevToken = lastPrevToken
+        while (prevToken) {
+          const res = await paginator.paginate({
+            query: baseBuilder(),
+            sorts,
+            limit,
+            cursor: { prevPage: prevToken },
+          })
+          backwardPages.push(res.items)
+          prevToken = res.prevPage
+        }
+
+        // the backward walk replays every forward page except the one we started from, in reverse
+        expect(ids(backwardPages)).toEqual(ids(forwardPages.slice(0, -1).reverse()))
+      }
+    }
+  })
+
   it('throws on malformed page tokens', async () => {
     const { page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
       { col: 'users.created_at', dir: 'asc' },
       { col: 'users.id', dir: 'asc' },
     ]
-    await expect(page(5, sorts, 'this-is-not-a-valid-token')).rejects.toThrowError(/Failed to paginate/i)
+    await expect(page(5, sorts, 'this-is-not-a-valid-token')).rejects.toMatchObject({
+      code: 'INVALID_TOKEN',
+      message: 'Invalid page token',
+    })
   })
 
   it('throws when page token does not match the provided sort signature', async () => {

--- a/test/dialect/shared.ts
+++ b/test/dialect/shared.ts
@@ -52,16 +52,61 @@ export interface DatabaseConfig {
   dialect: PaginationDialect
   createTable: (db: Kysely<TestDB>) => Promise<void>
   insertTestData: (db: Kysely<TestDB>, rows: Omit<TestRow, 'id'>[]) => Promise<void>
-  applySortToQuery: (query: any, sorts: SortSet<TestDB, 'users', TestRow>) => any
+}
+
+const stripTable = (col: string) => col.replace(/^users\./, '')
+
+const effectiveNulls = (
+  meta: DialectMeta,
+  dir: 'asc' | 'desc',
+  explicit: NullsDirection | undefined
+): NullsDirection => {
+  if (explicit) return explicit
+  return dir === 'asc'
+    ? meta.defaultNullsSortAsc
+    : invertNulls(meta.defaultNullsSortAsc)
+}
+
+const compareRows = (
+  a: TestRow,
+  b: TestRow,
+  sorts: SortSet<TestDB, 'users', TestRow>,
+  meta: DialectMeta
+): number => {
+  for (const s of sorts) {
+    const col = stripTable(s.col as string)
+    const dir = (s.dir ?? 'asc') as 'asc' | 'desc'
+    const an = (a as any)[col]
+    const bn = (b as any)[col]
+    const nulls = effectiveNulls(meta, dir, s.nulls)
+
+    // null-handling first
+    const aIsNull = an == null
+    const bIsNull = bn == null
+    if (aIsNull || bIsNull) {
+      if (aIsNull && bIsNull) {
+        // equal on this column, continue to next
+      } else if (aIsNull) {
+        return nulls === 'first' ? -1 : 1
+      } else {
+        return nulls === 'first' ? 1 : -1
+      }
+    } else {
+      // both non-null: normal compare
+      if (an < bn) return dir === 'asc' ? -1 : 1
+      if (an > bn) return dir === 'asc' ? 1 : -1
+    }
+  }
+
+  return 0
 }
 
 export const createTestHelpers = (db: Kysely<TestDB>, config: DatabaseConfig) => {
   const baseBuilder = () => db.selectFrom('users').select(['id', 'name', 'created_at', 'rating', 'active'])
 
   const fetchAllPlainSorted = async (sorts: SortSet<TestDB, 'users', TestRow>) => {
-    let q = baseBuilder()
-    q = config.applySortToQuery(q, sorts)
-    return await q.execute()
+    const rows = await baseBuilder().execute()
+    return [...rows].sort((a, b) => compareRows(a, b, sorts, config.dialect.meta))
   }
 
   const cursorCodec = codecPipe(superJsonCodec, base64UrlCodec)

--- a/test/dialect/shared.ts
+++ b/test/dialect/shared.ts
@@ -1,13 +1,13 @@
-import type { Generated, Kysely, Selectable } from 'kysely'
+import type { Generated, Kysely, OrderByDirection, Selectable } from 'kysely'
 
 import { base64UrlCodec } from '~/codec/base64Url.js'
 import { codecPipe } from '~/codec/codec.js'
 import { superJsonCodec } from '~/codec/superJson.js'
-import { resolveCursor } from '~/cursor.js'
+import { invertNulls, resolveCursor } from '~/cursor.js'
 import type { PaginatedResult } from '~/index.js'
 import { createPaginator } from '~/index.js'
-import type { SortSet } from '~/sorting.js'
-import type { PaginationDialect } from '~/types.js'
+import { NullsDirection, SortSet } from '~/sorting.js'
+import { DialectMeta, PaginationDialect } from '~/types.js'
 
 export interface UsersTable {
   id: Generated<number>
@@ -28,21 +28,21 @@ export const createTestData = () => {
   const mkDate = (days: number) => new Date(base.getTime() + days * 24 * 60 * 60 * 1000)
 
   const rows: Omit<TestRow, 'id'>[] = [
-    { name: 'Ava', created_at: mkDate(0), rating: null, active: true },
-    { name: 'Ben', created_at: mkDate(0), rating: 5, active: false },
-    { name: 'Chloé', created_at: mkDate(1), rating: 3, active: true },
-    { name: 'Drew', created_at: mkDate(2), rating: null, active: true },
-    { name: 'Eli', created_at: mkDate(2), rating: 1, active: false },
-    { name: 'Finn', created_at: mkDate(3), rating: 10, active: true },
-    { name: 'Gus', created_at: mkDate(3), rating: null, active: true },
-    { name: 'Hana', created_at: mkDate(4), rating: 4, active: false },
-    { name: 'Ivy', created_at: mkDate(4), rating: 7, active: true },
-    { name: 'Jude', created_at: mkDate(5), rating: null, active: false },
-    { name: 'Kai', created_at: mkDate(6), rating: 2, active: true },
-    { name: 'Luz', created_at: mkDate(6), rating: 8, active: true },
-    { name: 'Mia', created_at: mkDate(7), rating: null, active: true },
-    { name: 'Noah', created_at: mkDate(8), rating: 9, active: true },
-    { name: 'Oli', created_at: mkDate(9), rating: 6, active: false },
+    {name: 'Ava', created_at: mkDate(0), rating: null, active: true},
+    {name: 'Ben', created_at: mkDate(0), rating: 5, active: false},
+    {name: 'Chloé', created_at: mkDate(1), rating: 3, active: true},
+    {name: 'Drew', created_at: mkDate(2), rating: null, active: true},
+    {name: 'Eli', created_at: mkDate(2), rating: 1, active: false},
+    {name: 'Finn', created_at: mkDate(3), rating: 10, active: true},
+    {name: 'Gus', created_at: mkDate(3), rating: null, active: true},
+    {name: 'Hana', created_at: mkDate(4), rating: 4, active: false},
+    {name: 'Ivy', created_at: mkDate(4), rating: 7, active: true},
+    {name: 'Jude', created_at: mkDate(5), rating: null, active: false},
+    {name: 'Kai', created_at: mkDate(6), rating: 2, active: true},
+    {name: 'Luz', created_at: mkDate(6), rating: 8, active: true},
+    {name: 'Mia', created_at: mkDate(7), rating: null, active: true},
+    {name: 'Noah', created_at: mkDate(8), rating: 9, active: true},
+    {name: 'Oli', created_at: mkDate(9), rating: 6, active: false},
   ]
 
   return rows
@@ -80,11 +80,11 @@ export const createTestHelpers = (db: Kysely<TestDB>, config: DatabaseConfig) =>
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: token ? { nextPage: token } : undefined,
+      cursor: token ? {nextPage: token} : undefined,
     })
   }
 
-  return { baseBuilder, fetchAllPlainSorted, paginator, page }
+  return {baseBuilder, fetchAllPlainSorted, paginator, page}
 }
 
 export const resolveNextPageToken = async (items: TestRow[], sorts: SortSet<TestDB, 'users', TestRow>) => {
@@ -95,13 +95,17 @@ export const resolveNextPageToken = async (items: TestRow[], sorts: SortSet<Test
   return await cursorCodec.encode(payload)
 }
 
-export const runSharedTests = (createHelpers: () => ReturnType<typeof createTestHelpers>, dialect: string) => {
+const nullsForDir = (defaultNullsSortAsc: NullsDirection, dir: OrderByDirection) => {
+  return dir === 'desc' ? invertNulls(defaultNullsSortAsc) : defaultNullsSortAsc
+}
+
+export const runSharedTests = (createHelpers: () => ReturnType<typeof createTestHelpers>, dialectName: string, meta: DialectMeta) => {
   it('paginates deterministically by created_at ASC, id ASC (with continuity across pages)', async () => {
-    const { fetchAllPlainSorted, page } = createHelpers()
+    const {fetchAllPlainSorted, page} = createHelpers()
 
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
@@ -132,10 +136,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('returns a nextPage token when more rows exist, and omits it on the last page', async () => {
-    const { page } = createHelpers()
+    const {page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
     const first = await page(4, sorts)
     expect(first.items).toHaveLength(4)
@@ -154,20 +158,27 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
     expect(nearEnd.nextPage).toBeUndefined()
   })
 
-  it(`respects ${dialect} NULLS behavior and paginates with NULLs`, async () => {
-    const { fetchAllPlainSorted, page } = createHelpers()
+  it(`respects ${dialectName} NULLS behavior and paginates with NULLs`, async () => {
+    const {fetchAllPlainSorted, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.rating', dir: 'asc' }, // NULLS behavior varies by dialect
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.rating', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
+
     const expected = await fetchAllPlainSorted(sorts)
-
-    // First page should start with the NULL ratings (both dialects have NULLS FIRST for ASC)
     const first = await page(3, sorts)
-    expect(first.items).toHaveLength(3)
-    expect(first.items.every((r) => r.rating === null)).toBe(true)
 
-    // Continue paging and compare to expected
+    const ascNulls = nullsForDir(meta.defaultNullsSortAsc, 'asc')
+
+    if (ascNulls === 'first') {
+      // dialect puts NULLs first for ASC (mssql/mysql/sqlite)
+      expect(first.items).toHaveLength(3)
+      expect(first.items.every((r) => r.rating === null)).toBe(true)
+    } else {
+      // dialect puts NULLs last for ASC (postgres in the new impl)
+      expect(first.items.some((r) => r.rating !== null)).toBe(true)
+    }
+
     const all: TestRow[] = []
     let token: string | undefined = undefined
     do {
@@ -179,21 +190,26 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
     expect(all.map((r) => r.id)).toEqual(expected.map((r) => r.id))
   })
 
-  it(`supports DESC ordering with NULLS LAST (${dialect} default) and paginates properly`, async () => {
-    const { fetchAllPlainSorted, page } = createHelpers()
+  it(`supports DESC ordering with dialect NULLS behavior (${dialectName}) and paginates properly`, async () => {
+    const {fetchAllPlainSorted, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.rating', dir: 'desc' }, // NULLS LAST (default for DESC)
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.rating', dir: 'desc'},
+      {col: 'users.id', dir: 'asc'},
     ]
     const expected = await fetchAllPlainSorted(sorts)
 
     const first = await page(5, sorts)
     expect(first.items).toHaveLength(5)
-    // The first page should not start with null ratings here (NULLS LAST for DESC)
-    expect(first.items.some((r) => r.rating !== null)).toBe(true)
-    expect(first.items[0]!.rating).not.toBeNull()
 
-    // Collect everything and compare to expected
+    const descNulls = nullsForDir(meta.defaultNullsSortAsc, 'desc')
+    if (descNulls === 'last') {
+      // non-null ratings should come first
+      expect(first.items[0]!.rating).not.toBeNull()
+    } else {
+      // NULLs FIRST for DESC
+      expect(first.items[0]!.rating).toBeNull()
+    }
+
     const all: TestRow[] = []
     let token: string | undefined
     do {
@@ -204,24 +220,53 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
     expect(all.map((r) => r.id)).toEqual(expected.map((r) => r.id))
   })
 
-  it('throws on malformed page tokens', async () => {
-    const { page } = createHelpers()
+  // NEW: make sure explicit nulls directive is either honored or rejected per dialect
+  it('handles explicit NULLS directive according to dialect support', async () => {
+    const {page, fetchAllPlainSorted} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.rating', dir: 'asc', nulls: 'last'}, // force opposite of most defaults
+      {col: 'users.id', dir: 'asc'},
+    ]
+
+    if (meta.supportsNullSortDirective) {
+      const expected = await fetchAllPlainSorted(sorts)
+      const first = await page(3, sorts)
+      // because we explicitly asked for NULLS LAST, the first page should start with non-NULLs
+      expect(first.items.some((r) => r.rating !== null)).toBe(true)
+
+      // and full pagination still matches db order
+      const all: TestRow[] = []
+      let token: string | undefined
+      do {
+        const res = await page(3, sorts, token)
+        all.push(...res.items)
+        token = res.nextPage
+      } while (token)
+      expect(all.map((r) => r.id)).toEqual(expected.map((r) => r.id))
+    } else {
+      // dialect should throw because the impl throws in BasePaginationDialect.applySort
+      await expect(page(3, sorts)).rejects.toThrow(/does not support nulls first\/last/i)
+    }
+  })
+
+  it('throws on malformed page tokens', async () => {
+    const {page} = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
     await expect(page(5, sorts, 'this-is-not-a-valid-token')).rejects.toThrowError(/Failed to paginate/i)
   })
 
   it('throws when page token does not match the provided sort signature', async () => {
-    const { page } = createHelpers()
+    const {page} = createHelpers()
     const sortsA: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
     const sortsB: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'desc' }, // different direction => different signature
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'desc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const first = await page(3, sortsA)
@@ -231,17 +276,16 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('throws when page token is missing required cursor key(s)', async () => {
-    const { fetchAllPlainSorted, page } = createHelpers()
+    const {fetchAllPlainSorted, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
     const first = expected[0]!
 
     const payload = resolveCursor(first, sorts)
-    // remove a required key to simulate a token with a valid signature but missing data
     delete (payload as any).k.id
 
     const codec = codecPipe(superJsonCodec, base64UrlCodec)
@@ -251,10 +295,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('can paginate with a boolean sort and a secondary tie-breaker', async () => {
-    const { fetchAllPlainSorted, page } = createHelpers()
+    const {fetchAllPlainSorted, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.active', dir: 'desc' }, // true first
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.active', dir: 'desc'},
+      {col: 'users.id', dir: 'asc'},
     ]
     const expected = await fetchAllPlainSorted(sorts)
 
@@ -267,25 +311,22 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
     } while (token)
 
     expect(all.map((r) => r.id)).toEqual(expected.map((r) => r.id))
-    // First chunk should be all active users until they run out (desc => true first)
     expect(all.find((r) => r.active === false)).toBeTruthy()
   })
 
-  it('paginates DESC with trailing NULLs across page boundaries (no rewinds/dupes)', async () => {
-    const { fetchAllPlainSorted, page } = createHelpers()
+  // make this dialect-aware, not "DESC with trailing NULLs"
+  it('paginates DESC across page boundaries without rewinds/dupes around NULLs', async () => {
+    const {fetchAllPlainSorted, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.rating', dir: 'desc' }, // NULLS LAST
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.rating', dir: 'desc'},
+      {col: 'users.id', dir: 'asc'},
     ]
     const expected = await fetchAllPlainSorted(sorts)
 
-    // Small limit to force a boundary inside the NULL block.
     const limit = 2
-
     const seen: TestRow[] = []
     let token: string | undefined
     for (let i = 0; i < 8; i++) {
-      // enough iterations to pass through the NULL tail
       const res = await page(limit, sorts, token)
       seen.push(...res.items)
       if (!res.nextPage) break
@@ -295,11 +336,11 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
     expect(seen.map((r) => r.id)).toEqual(expected.map((r) => r.id))
   })
 
-  it('paginates ASC with leading NULLs across page boundaries (no gaps)', async () => {
-    const { fetchAllPlainSorted, page } = createHelpers()
+  it('paginates ASC across page boundaries (incl. possible leading NULLs) with no gaps', async () => {
+    const {fetchAllPlainSorted, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'rating', dir: 'asc' }, // NULLS FIRST
-      { col: 'id', dir: 'asc' },
+      {col: 'rating', dir: 'asc'},
+      {col: 'id', dir: 'asc'},
     ]
     const expected = await fetchAllPlainSorted(sorts)
 
@@ -315,12 +356,12 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
     expect(seen.map((r) => r.id)).toEqual(expected.map((r) => r.id))
   })
 
-  it('paginates DESC when a nullable key is not first (NULLS LAST) without gaps', async () => {
-    const { fetchAllPlainSorted, page } = createHelpers()
+  it('paginates DESC when a nullable key is not first without gaps', async () => {
+    const {fetchAllPlainSorted, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' }, // non-null
-      { col: 'users.rating', dir: 'desc' }, // NULLS LAST, nullable and NOT first
-      { col: 'users.id', dir: 'asc' }, // tie-breaker
+      {col: 'users.created_at', dir: 'asc'}, // non-null
+      {col: 'users.rating', dir: 'desc'}, // NULLS LAST, nullable and NOT first
+      {col: 'users.id', dir: 'asc'}, // tie-breaker
     ]
     const expected = await fetchAllPlainSorted(sorts)
     const seen: TestRow[] = []
@@ -334,10 +375,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('orders boolean DESC with a clean true-prefix before falses', async () => {
-    const { page } = createHelpers()
+    const {page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.active', dir: 'desc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.active', dir: 'desc'},
+      {col: 'users.id', dir: 'asc'},
     ]
     const first = await page(100, sorts)
     const firstFalseIdx = first.items.findIndex((r) => r.active === false)
@@ -349,17 +390,17 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('validates limit and sorts (throws on invalid limit)', async () => {
-    const { page } = createHelpers()
-    const sorts: SortSet<TestDB, 'users', TestRow> = [{ col: 'users.id', dir: 'asc' }]
+    const {page} = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [{col: 'users.id', dir: 'asc'}]
     // Invalid: limit <= 0
     await expect(page(0, sorts)).rejects.toThrowError(/Invalid page size limit/i)
   })
 
   it('supports prevPage navigation (backward) and preserves item order', async () => {
-    const { baseBuilder, paginator, page } = createHelpers()
+    const {baseBuilder, paginator, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const limit = 5
@@ -373,7 +414,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: { prevPage: second.prevPage! },
+      cursor: {prevPage: second.prevPage!},
     })
 
     // Should equal the first page items, in the same order
@@ -385,16 +426,16 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: { nextPage: back.nextPage! },
+      cursor: {nextPage: back.nextPage!},
     })
     expect(forwardAgain.items.map((r) => r.id)).toEqual(second.items.map((r) => r.id))
   })
 
   it('supports offset/limit pagination across multiple pages', async () => {
-    const { baseBuilder, fetchAllPlainSorted, paginator } = createHelpers()
+    const {baseBuilder, fetchAllPlainSorted, paginator} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
@@ -405,7 +446,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
         query: baseBuilder(),
         sorts,
         limit,
-        cursor: { offset },
+        cursor: {offset},
       })
 
       const expectedSlice = expected.slice(offset, offset + limit)
@@ -434,10 +475,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('emits correct startCursor/endCursor for forward paging', async () => {
-    const { page } = createHelpers()
+    const {page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const first = await page(5, sorts)
@@ -456,10 +497,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('emits correct start/end cursors when navigating with prevPage', async () => {
-    const { baseBuilder, paginator, page } = createHelpers()
+    const {baseBuilder, paginator, page} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const limit = 5
@@ -470,7 +511,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: { prevPage: second.prevPage! },
+      cursor: {prevPage: second.prevPage!},
     })
 
     const codec = codecPipe(superJsonCodec, base64UrlCodec)
@@ -481,10 +522,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('emits correct start/end cursors for offset pages and none for empty pages', async () => {
-    const { baseBuilder, paginator } = createHelpers()
+    const {baseBuilder, paginator} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const limit = 5
@@ -494,7 +535,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: { offset: 5 },
+      cursor: {offset: 5},
     })
     const codec = codecPipe(superJsonCodec, base64UrlCodec)
     const expectedMidStart = await codec.encode(resolveCursor(mid.items[0]!, sorts))
@@ -507,7 +548,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: { offset: 999 },
+      cursor: {offset: 999},
     })
     expect(empty.items).toHaveLength(0)
     expect(empty.startCursor).toBeUndefined()
@@ -515,10 +556,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('starts mid-way with offset, then continues using cursor tokens', async () => {
-    const { baseBuilder, fetchAllPlainSorted, paginator } = createHelpers()
+    const {baseBuilder, fetchAllPlainSorted, paginator} = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc' },
-      { col: 'users.id', dir: 'asc' },
+      {col: 'users.created_at', dir: 'asc'},
+      {col: 'users.id', dir: 'asc'},
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
@@ -529,7 +570,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: { offset: 5 },
+      cursor: {offset: 5},
     })
 
     expect(mid.items.map((r) => r.id)).toEqual(expected.slice(5, 10).map((r) => r.id))
@@ -545,7 +586,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
         query: baseBuilder(),
         sorts,
         limit,
-        cursor: { nextPage: next },
+        cursor: {nextPage: next},
       })
       seenForward.push(...res.items)
       next = res.nextPage
@@ -558,7 +599,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: { prevPage: mid.prevPage! },
+      cursor: {prevPage: mid.prevPage!},
     })
     expect(back.items.map((r) => r.id)).toEqual(expected.slice(0, 5).map((r) => r.id))
   })

--- a/test/dialect/shared.ts
+++ b/test/dialect/shared.ts
@@ -28,21 +28,21 @@ export const createTestData = () => {
   const mkDate = (days: number) => new Date(base.getTime() + days * 24 * 60 * 60 * 1000)
 
   const rows: Omit<TestRow, 'id'>[] = [
-    {name: 'Ava', created_at: mkDate(0), rating: null, active: true},
-    {name: 'Ben', created_at: mkDate(0), rating: 5, active: false},
-    {name: 'Chloé', created_at: mkDate(1), rating: 3, active: true},
-    {name: 'Drew', created_at: mkDate(2), rating: null, active: true},
-    {name: 'Eli', created_at: mkDate(2), rating: 1, active: false},
-    {name: 'Finn', created_at: mkDate(3), rating: 10, active: true},
-    {name: 'Gus', created_at: mkDate(3), rating: null, active: true},
-    {name: 'Hana', created_at: mkDate(4), rating: 4, active: false},
-    {name: 'Ivy', created_at: mkDate(4), rating: 7, active: true},
-    {name: 'Jude', created_at: mkDate(5), rating: null, active: false},
-    {name: 'Kai', created_at: mkDate(6), rating: 2, active: true},
-    {name: 'Luz', created_at: mkDate(6), rating: 8, active: true},
-    {name: 'Mia', created_at: mkDate(7), rating: null, active: true},
-    {name: 'Noah', created_at: mkDate(8), rating: 9, active: true},
-    {name: 'Oli', created_at: mkDate(9), rating: 6, active: false},
+    { name: 'Ava', created_at: mkDate(0), rating: null, active: true },
+    { name: 'Ben', created_at: mkDate(0), rating: 5, active: false },
+    { name: 'Chloé', created_at: mkDate(1), rating: 3, active: true },
+    { name: 'Drew', created_at: mkDate(2), rating: null, active: true },
+    { name: 'Eli', created_at: mkDate(2), rating: 1, active: false },
+    { name: 'Finn', created_at: mkDate(3), rating: 10, active: true },
+    { name: 'Gus', created_at: mkDate(3), rating: null, active: true },
+    { name: 'Hana', created_at: mkDate(4), rating: 4, active: false },
+    { name: 'Ivy', created_at: mkDate(4), rating: 7, active: true },
+    { name: 'Jude', created_at: mkDate(5), rating: null, active: false },
+    { name: 'Kai', created_at: mkDate(6), rating: 2, active: true },
+    { name: 'Luz', created_at: mkDate(6), rating: 8, active: true },
+    { name: 'Mia', created_at: mkDate(7), rating: null, active: true },
+    { name: 'Noah', created_at: mkDate(8), rating: 9, active: true },
+    { name: 'Oli', created_at: mkDate(9), rating: 6, active: false },
   ]
 
   return rows
@@ -59,20 +59,13 @@ const stripTable = (col: string) => col.replace(/^users\./, '')
 const effectiveNulls = (
   meta: DialectMeta,
   dir: 'asc' | 'desc',
-  explicit: NullsDirection | undefined
+  explicit: NullsDirection | undefined,
 ): NullsDirection => {
   if (explicit) return explicit
-  return dir === 'asc'
-    ? meta.defaultNullsSortAsc
-    : invertNulls(meta.defaultNullsSortAsc)
+  return dir === 'asc' ? meta.defaultNullsSortAsc : invertNulls(meta.defaultNullsSortAsc)
 }
 
-const compareRows = (
-  a: TestRow,
-  b: TestRow,
-  sorts: SortSet<TestDB, 'users', TestRow>,
-  meta: DialectMeta
-): number => {
+const compareRows = (a: TestRow, b: TestRow, sorts: SortSet<TestDB, 'users', TestRow>, meta: DialectMeta): number => {
   for (const s of sorts) {
     const col = stripTable(s.col as string)
     const dir = (s.dir ?? 'asc') as 'asc' | 'desc'
@@ -125,11 +118,11 @@ export const createTestHelpers = (db: Kysely<TestDB>, config: DatabaseConfig) =>
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: token ? {nextPage: token} : undefined,
+      cursor: token ? { nextPage: token } : undefined,
     })
   }
 
-  return {baseBuilder, fetchAllPlainSorted, paginator, page}
+  return { baseBuilder, fetchAllPlainSorted, paginator, page }
 }
 
 export const resolveNextPageToken = async (items: TestRow[], sorts: SortSet<TestDB, 'users', TestRow>) => {
@@ -144,13 +137,17 @@ const nullsForDir = (defaultNullsSortAsc: NullsDirection, dir: OrderByDirection)
   return dir === 'desc' ? invertNulls(defaultNullsSortAsc) : defaultNullsSortAsc
 }
 
-export const runSharedTests = (createHelpers: () => ReturnType<typeof createTestHelpers>, dialectName: string, meta: DialectMeta) => {
+export const runSharedTests = (
+  createHelpers: () => ReturnType<typeof createTestHelpers>,
+  dialectName: string,
+  meta: DialectMeta,
+) => {
   it('paginates deterministically by created_at ASC, id ASC (with continuity across pages)', async () => {
-    const {fetchAllPlainSorted, page} = createHelpers()
+    const { fetchAllPlainSorted, page } = createHelpers()
 
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
@@ -181,10 +178,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('returns a nextPage token when more rows exist, and omits it on the last page', async () => {
-    const {page} = createHelpers()
+    const { page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
     const first = await page(4, sorts)
     expect(first.items).toHaveLength(4)
@@ -204,10 +201,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it(`respects ${dialectName} NULLS behavior and paginates with NULLs`, async () => {
-    const {fetchAllPlainSorted, page} = createHelpers()
+    const { fetchAllPlainSorted, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.rating', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.rating', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
@@ -236,10 +233,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it(`supports DESC ordering with dialect NULLS behavior (${dialectName}) and paginates properly`, async () => {
-    const {fetchAllPlainSorted, page} = createHelpers()
+    const { fetchAllPlainSorted, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.rating', dir: 'desc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.rating', dir: 'desc' },
+      { col: 'users.id', dir: 'asc' },
     ]
     const expected = await fetchAllPlainSorted(sorts)
 
@@ -267,10 +264,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
 
   // NEW: make sure explicit nulls directive is either honored or rejected per dialect
   it('handles explicit NULLS directive according to dialect support', async () => {
-    const {page, fetchAllPlainSorted} = createHelpers()
+    const { page, fetchAllPlainSorted } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.rating', dir: 'asc', nulls: 'last'}, // force opposite of most defaults
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.rating', dir: 'asc', nulls: 'last' }, // force opposite of most defaults
+      { col: 'users.id', dir: 'asc' },
     ]
 
     if (meta.supportsNullSortDirective) {
@@ -295,23 +292,23 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('throws on malformed page tokens', async () => {
-    const {page} = createHelpers()
+    const { page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
     await expect(page(5, sorts, 'this-is-not-a-valid-token')).rejects.toThrowError(/Failed to paginate/i)
   })
 
   it('throws when page token does not match the provided sort signature', async () => {
-    const {page} = createHelpers()
+    const { page } = createHelpers()
     const sortsA: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
     const sortsB: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'desc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'desc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const first = await page(3, sortsA)
@@ -321,10 +318,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('throws when page token is missing required cursor key(s)', async () => {
-    const {fetchAllPlainSorted, page} = createHelpers()
+    const { fetchAllPlainSorted, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
@@ -340,10 +337,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('can paginate with a boolean sort and a secondary tie-breaker', async () => {
-    const {fetchAllPlainSorted, page} = createHelpers()
+    const { fetchAllPlainSorted, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.active', dir: 'desc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.active', dir: 'desc' },
+      { col: 'users.id', dir: 'asc' },
     ]
     const expected = await fetchAllPlainSorted(sorts)
 
@@ -361,10 +358,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
 
   // make this dialect-aware, not "DESC with trailing NULLs"
   it('paginates DESC across page boundaries without rewinds/dupes around NULLs', async () => {
-    const {fetchAllPlainSorted, page} = createHelpers()
+    const { fetchAllPlainSorted, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.rating', dir: 'desc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.rating', dir: 'desc' },
+      { col: 'users.id', dir: 'asc' },
     ]
     const expected = await fetchAllPlainSorted(sorts)
 
@@ -382,10 +379,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('paginates ASC across page boundaries (incl. possible leading NULLs) with no gaps', async () => {
-    const {fetchAllPlainSorted, page} = createHelpers()
+    const { fetchAllPlainSorted, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'rating', dir: 'asc'},
-      {col: 'id', dir: 'asc'},
+      { col: 'rating', dir: 'asc' },
+      { col: 'id', dir: 'asc' },
     ]
     const expected = await fetchAllPlainSorted(sorts)
 
@@ -402,11 +399,11 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('paginates DESC when a nullable key is not first without gaps', async () => {
-    const {fetchAllPlainSorted, page} = createHelpers()
+    const { fetchAllPlainSorted, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'}, // non-null
-      {col: 'users.rating', dir: 'desc'}, // NULLS LAST, nullable and NOT first
-      {col: 'users.id', dir: 'asc'}, // tie-breaker
+      { col: 'users.created_at', dir: 'asc' }, // non-null
+      { col: 'users.rating', dir: 'desc' }, // NULLS LAST, nullable and NOT first
+      { col: 'users.id', dir: 'asc' }, // tie-breaker
     ]
     const expected = await fetchAllPlainSorted(sorts)
     const seen: TestRow[] = []
@@ -420,10 +417,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('orders boolean DESC with a clean true-prefix before falses', async () => {
-    const {page} = createHelpers()
+    const { page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.active', dir: 'desc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.active', dir: 'desc' },
+      { col: 'users.id', dir: 'asc' },
     ]
     const first = await page(100, sorts)
     const firstFalseIdx = first.items.findIndex((r) => r.active === false)
@@ -435,17 +432,17 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('validates limit and sorts (throws on invalid limit)', async () => {
-    const {page} = createHelpers()
-    const sorts: SortSet<TestDB, 'users', TestRow> = [{col: 'users.id', dir: 'asc'}]
+    const { page } = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [{ col: 'users.id', dir: 'asc' }]
     // Invalid: limit <= 0
     await expect(page(0, sorts)).rejects.toThrowError(/Invalid page size limit/i)
   })
 
   it('supports prevPage navigation (backward) and preserves item order', async () => {
-    const {baseBuilder, paginator, page} = createHelpers()
+    const { baseBuilder, paginator, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const limit = 5
@@ -459,7 +456,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: {prevPage: second.prevPage!},
+      cursor: { prevPage: second.prevPage! },
     })
 
     // Should equal the first page items, in the same order
@@ -471,16 +468,16 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: {nextPage: back.nextPage!},
+      cursor: { nextPage: back.nextPage! },
     })
     expect(forwardAgain.items.map((r) => r.id)).toEqual(second.items.map((r) => r.id))
   })
 
   it('supports offset/limit pagination across multiple pages', async () => {
-    const {baseBuilder, fetchAllPlainSorted, paginator} = createHelpers()
+    const { baseBuilder, fetchAllPlainSorted, paginator } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
@@ -491,7 +488,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
         query: baseBuilder(),
         sorts,
         limit,
-        cursor: {offset},
+        cursor: { offset },
       })
 
       const expectedSlice = expected.slice(offset, offset + limit)
@@ -520,10 +517,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('emits correct startCursor/endCursor for forward paging', async () => {
-    const {page} = createHelpers()
+    const { page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const first = await page(5, sorts)
@@ -542,10 +539,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('emits correct start/end cursors when navigating with prevPage', async () => {
-    const {baseBuilder, paginator, page} = createHelpers()
+    const { baseBuilder, paginator, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const limit = 5
@@ -556,7 +553,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: {prevPage: second.prevPage!},
+      cursor: { prevPage: second.prevPage! },
     })
 
     const codec = codecPipe(superJsonCodec, base64UrlCodec)
@@ -567,10 +564,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('emits correct start/end cursors for offset pages and none for empty pages', async () => {
-    const {baseBuilder, paginator} = createHelpers()
+    const { baseBuilder, paginator } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const limit = 5
@@ -580,7 +577,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: {offset: 5},
+      cursor: { offset: 5 },
     })
     const codec = codecPipe(superJsonCodec, base64UrlCodec)
     const expectedMidStart = await codec.encode(resolveCursor(mid.items[0]!, sorts))
@@ -593,7 +590,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: {offset: 999},
+      cursor: { offset: 999 },
     })
     expect(empty.items).toHaveLength(0)
     expect(empty.startCursor).toBeUndefined()
@@ -601,10 +598,10 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
   })
 
   it('starts mid-way with offset, then continues using cursor tokens', async () => {
-    const {baseBuilder, fetchAllPlainSorted, paginator} = createHelpers()
+    const { baseBuilder, fetchAllPlainSorted, paginator } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      {col: 'users.created_at', dir: 'asc'},
-      {col: 'users.id', dir: 'asc'},
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
     ]
 
     const expected = await fetchAllPlainSorted(sorts)
@@ -615,7 +612,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: {offset: 5},
+      cursor: { offset: 5 },
     })
 
     expect(mid.items.map((r) => r.id)).toEqual(expected.slice(5, 10).map((r) => r.id))
@@ -631,7 +628,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
         query: baseBuilder(),
         sorts,
         limit,
-        cursor: {nextPage: next},
+        cursor: { nextPage: next },
       })
       seenForward.push(...res.items)
       next = res.nextPage
@@ -644,7 +641,7 @@ export const runSharedTests = (createHelpers: () => ReturnType<typeof createTest
       query: baseBuilder(),
       sorts,
       limit,
-      cursor: {prevPage: mid.prevPage!},
+      cursor: { prevPage: mid.prevPage! },
     })
     expect(back.items.map((r) => r.id)).toEqual(expected.slice(0, 5).map((r) => r.id))
   })

--- a/test/dialect/shared.ts
+++ b/test/dialect/shared.ts
@@ -23,26 +23,25 @@ export interface TestDB {
 
 export type TestRow = Selectable<UsersTable>
 
-export const createTestData = () => {
-  const base = new Date('2023-01-01T00:00:00.000Z')
-  const mkDate = (days: number) => new Date(base.getTime() + days * 24 * 60 * 60 * 1000)
+export const testDay = (days: number) => new Date(Date.UTC(2023, 0, 1 + days))
 
+export const createTestData = () => {
   const rows: Omit<TestRow, 'id'>[] = [
-    { name: 'Ava', created_at: mkDate(0), rating: null, active: true },
-    { name: 'Ben', created_at: mkDate(0), rating: 5, active: false },
-    { name: 'Chloé', created_at: mkDate(1), rating: 3, active: true },
-    { name: 'Drew', created_at: mkDate(2), rating: null, active: true },
-    { name: 'Eli', created_at: mkDate(2), rating: 1, active: false },
-    { name: 'Finn', created_at: mkDate(3), rating: 10, active: true },
-    { name: 'Gus', created_at: mkDate(3), rating: null, active: true },
-    { name: 'Hana', created_at: mkDate(4), rating: 4, active: false },
-    { name: 'Ivy', created_at: mkDate(4), rating: 7, active: true },
-    { name: 'Jude', created_at: mkDate(5), rating: null, active: false },
-    { name: 'Kai', created_at: mkDate(6), rating: 2, active: true },
-    { name: 'Luz', created_at: mkDate(6), rating: 8, active: true },
-    { name: 'Mia', created_at: mkDate(7), rating: null, active: true },
-    { name: 'Noah', created_at: mkDate(8), rating: 9, active: true },
-    { name: 'Oli', created_at: mkDate(9), rating: 6, active: false },
+    { name: 'Ava', created_at: testDay(0), rating: null, active: true },
+    { name: 'Ben', created_at: testDay(0), rating: 5, active: false },
+    { name: 'Chloé', created_at: testDay(1), rating: 3, active: true },
+    { name: 'Drew', created_at: testDay(2), rating: null, active: true },
+    { name: 'Eli', created_at: testDay(2), rating: 1, active: false },
+    { name: 'Finn', created_at: testDay(3), rating: 10, active: true },
+    { name: 'Gus', created_at: testDay(3), rating: null, active: true },
+    { name: 'Hana', created_at: testDay(4), rating: 4, active: false },
+    { name: 'Ivy', created_at: testDay(4), rating: 7, active: true },
+    { name: 'Jude', created_at: testDay(5), rating: null, active: false },
+    { name: 'Kai', created_at: testDay(6), rating: 2, active: true },
+    { name: 'Luz', created_at: testDay(6), rating: 8, active: true },
+    { name: 'Mia', created_at: testDay(7), rating: null, active: true },
+    { name: 'Noah', created_at: testDay(8), rating: 9, active: true },
+    { name: 'Oli', created_at: testDay(9), rating: 6, active: false },
   ]
 
   return rows
@@ -122,7 +121,18 @@ export const createTestHelpers = (db: Kysely<TestDB>, config: DatabaseConfig) =>
     })
   }
 
-  return { baseBuilder, fetchAllPlainSorted, paginator, page }
+  // mutation helpers for concurrency-stability tests. ids are always
+  // auto-generated (mssql IDENTITY forbids explicit inserts) and temp rows are
+  // addressed by their unique names, so the base fixture is never touched.
+  const insertRow = async (row: Omit<TestRow, 'id'>) => {
+    await config.insertTestData(db, [row])
+  }
+
+  const deleteRowsByName = async (names: string[]) => {
+    await db.deleteFrom('users').where('name', 'in', names).execute()
+  }
+
+  return { baseBuilder, deleteRowsByName, fetchAllPlainSorted, insertRow, paginator, page }
 }
 
 export const resolveNextPageToken = async (items: TestRow[], sorts: SortSet<TestDB, 'users', TestRow>) => {
@@ -378,7 +388,7 @@ export const runSharedTests = (
   // property: for any sort set and page size, paginating all the way forward and then
   // all the way back must replay the exact same pages in reverse order
   it('round-trips: forward then backward pagination replays identical pages', async () => {
-    const { baseBuilder, paginator } = createHelpers()
+    const { baseBuilder, fetchAllPlainSorted, paginator } = createHelpers()
 
     const sortVariants: SortSet<TestDB, 'users', TestRow>[] = [
       // non-nullable baseline
@@ -393,6 +403,19 @@ export const runSharedTests = (
       ],
       [
         { col: 'users.rating', dir: 'desc' },
+        { col: 'users.id', dir: 'asc' },
+      ],
+      // three-key sorts: the cursor predicate is recursive, and nested
+      // tie-breakers / NULL handling below the top level only get exercised
+      // from depth 2 down
+      [
+        { col: 'users.created_at', dir: 'asc' },
+        { col: 'users.rating', dir: 'desc' }, // nullable middle key
+        { col: 'users.id', dir: 'asc' },
+      ],
+      [
+        { col: 'users.rating', dir: 'asc' }, // nullable leading key with a deeper tie chain
+        { col: 'users.created_at', dir: 'desc' },
         { col: 'users.id', dir: 'asc' },
       ],
     ]
@@ -417,6 +440,7 @@ export const runSharedTests = (
     const ids = (pages: TestRow[][]) => pages.map((p) => p.map((r) => r.id))
 
     for (const sorts of sortVariants) {
+      const expected = await fetchAllPlainSorted(sorts)
       for (const limit of [1, 2, 3, 5]) {
         // walk forward through every page
         const forwardPages: TestRow[][] = []
@@ -433,6 +457,9 @@ export const runSharedTests = (
           nextToken = res.nextPage
           lastPrevToken = res.prevPage
         } while (nextToken)
+
+        // the forward walk reproduces the dialect's total order exactly
+        expect(forwardPages.flat().map((r) => r.id)).toEqual(expected.map((r) => r.id))
 
         // walk all the way back from the last page
         const backwardPages: TestRow[][] = []
@@ -451,6 +478,142 @@ export const runSharedTests = (
         // the backward walk replays every forward page except the one we started from, in reverse
         expect(ids(backwardPages)).toEqual(ids(forwardPages.slice(0, -1).reverse()))
       }
+    }
+  })
+
+  // the base fixture has no full ties on two leading keys, so a predicate that
+  // silently drops the deepest tie-breaker would still look correct there —
+  // manufacture a 3-way tie that only the final key can order
+  it('paginates 3-key sorts where the deepest tie-breaker decides order', async () => {
+    const { baseBuilder, deleteRowsByName, fetchAllPlainSorted, insertRow, paginator } = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.rating', dir: 'desc' }, // nullable middle key
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    // tie with the existing row id 3 (Chloé: day 1, rating 3)
+    await insertRow({ name: 'TieTestA', created_at: testDay(1), rating: 3, active: true })
+    await insertRow({ name: 'TieTestB', created_at: testDay(1), rating: 3, active: false })
+
+    try {
+      const expected = await fetchAllPlainSorted(sorts)
+
+      const tieIds = expected.filter((r) => ['Chloé', 'TieTestA', 'TieTestB'].includes(r.name)).map((r) => r.id)
+      expect(tieIds).toHaveLength(3)
+      // sanity: within the tie the oracle orders by id alone
+      expect(tieIds).toEqual([...tieIds].sort((a, b) => a - b))
+
+      // limit 2 splits the 3-row tie across two pages
+      const limit = 2
+      const forwardPages: TestRow[][] = []
+      let nextToken: string | undefined
+      let lastPrevToken: string | undefined
+      do {
+        const res = await paginator.paginate({
+          query: baseBuilder(),
+          sorts,
+          limit,
+          cursor: nextToken ? { nextPage: nextToken } : undefined,
+        })
+        forwardPages.push(res.items)
+        nextToken = res.nextPage
+        lastPrevToken = res.prevPage
+      } while (nextToken)
+
+      expect(forwardPages.flat().map((r) => r.id)).toEqual(expected.map((r) => r.id))
+
+      // and walking back from the end replays the same pages in reverse
+      const backwardPages: TestRow[][] = []
+      let prevToken = lastPrevToken
+      while (prevToken) {
+        const res = await paginator.paginate({
+          query: baseBuilder(),
+          sorts,
+          limit,
+          cursor: { prevPage: prevToken },
+        })
+        backwardPages.push(res.items)
+        prevToken = res.prevPage
+      }
+
+      const ids = (pages: TestRow[][]) => pages.map((p) => p.map((r) => r.id))
+      expect(ids(backwardPages)).toEqual(ids(forwardPages.slice(0, -1).reverse()))
+    } finally {
+      await deleteRowsByName(['TieTestA', 'TieTestB'])
+    }
+  })
+
+  // keyset's core promise vs OFFSET: a row inserted *before* the cursor position
+  // mid-walk must not shift, duplicate, or skip anything
+  it('is stable when a row is inserted before the cursor mid-walk', async () => {
+    const { deleteRowsByName, fetchAllPlainSorted, insertRow, page } = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    const expected = await fetchAllPlainSorted(sorts) // 15 rows, before the insert
+    const limit = 4
+
+    const first = await page(limit, sorts)
+    expect(first.items.map((r) => r.id)).toEqual(expected.slice(0, limit).map((r) => r.id))
+    expect(first.nextPage).toBeTruthy()
+
+    // sorts before the cursor row (id 4, day 2), but only after page 1 was read
+    await insertRow({ name: 'MutationInsert', created_at: testDay(0), rating: 9, active: true })
+
+    try {
+      const walked: TestRow[] = []
+      let token = first.nextPage
+      while (token) {
+        const res = await page(limit, sorts, token)
+        walked.push(...res.items)
+        token = res.nextPage
+      }
+
+      // exactly the remaining original rows — no dupes, no skips, no sign of the insert
+      expect(walked.map((r) => r.id)).toEqual(expected.slice(limit).map((r) => r.id))
+    } finally {
+      await deleteRowsByName(['MutationInsert'])
+    }
+  })
+
+  // the row a token points at can disappear between requests (concurrent delete) —
+  // the walk must continue from the token's sort position regardless
+  it('continues cleanly when the row behind the cursor token is deleted mid-walk', async () => {
+    const { deleteRowsByName, fetchAllPlainSorted, insertRow, page } = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    await insertRow({ name: 'MutationDelete', created_at: testDay(0), rating: 7, active: true })
+
+    try {
+      const expected = await fetchAllPlainSorted(sorts) // 16 rows, incl. the temp row
+      const tempId = expected.find((r) => r.name === 'MutationDelete')!.id
+      const limit = 3
+
+      // land the cursor exactly on the temp row, then delete it
+      const first = await page(limit, sorts)
+      expect(first.items.at(-1)!.id).toBe(tempId)
+      expect(first.nextPage).toBeTruthy()
+
+      await deleteRowsByName(['MutationDelete'])
+
+      const walked: TestRow[] = []
+      let token = first.nextPage
+      while (token) {
+        const res = await page(limit, sorts, token)
+        walked.push(...res.items)
+        token = res.nextPage
+      }
+
+      // the temp row sat inside page 1, so the continuation is unaffected by its absence
+      expect(walked.map((r) => r.id)).toEqual(expected.slice(limit).map((r) => r.id))
+    } finally {
+      await deleteRowsByName(['MutationDelete'])
     }
   })
 
@@ -597,11 +760,22 @@ export const runSharedTests = (
     expect(first.items.slice(firstFalseIdx).every((r) => r.active === false)).toBe(true)
   })
 
-  it('validates limit and sorts (throws on invalid limit)', async () => {
-    const { page } = createHelpers()
+  it('validates limit, offset and sorts (rejects bad input with 400-class codes)', async () => {
+    const { baseBuilder, page, paginator } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [{ col: 'users.id', dir: 'asc' }]
-    // Invalid: limit <= 0
+
     await expect(page(0, sorts)).rejects.toThrowError(/Invalid page size limit/i)
+    for (const limit of [-1, 1.5]) {
+      await expect(paginator.paginate({ query: baseBuilder(), sorts, limit })).rejects.toMatchObject({
+        code: 'INVALID_LIMIT',
+      })
+    }
+
+    for (const offset of [-1, 2.5]) {
+      await expect(
+        paginator.paginate({ query: baseBuilder(), sorts, limit: 5, cursor: { offset } }),
+      ).rejects.toMatchObject({ code: 'INVALID_TOKEN', message: 'Invalid pagination offset' })
+    }
   })
 
   it('supports prevPage navigation (backward) and preserves item order', async () => {

--- a/test/dialect/sqlite.test.ts
+++ b/test/dialect/sqlite.test.ts
@@ -41,7 +41,14 @@ describe('SQLite pagination helper', () => {
     applySortToQuery: (query, sorts) => {
       for (const s of sorts) {
         const dir = s.dir ?? 'asc'
-        query = query.orderBy(s.col, dir)
+        query = query.orderBy(s.col, (o: any) => {
+          const base = dir === 'asc' ? o.asc() : o.desc()
+
+          if (s.nulls === 'first') return base.nullsFirst()
+          if (s.nulls === 'last') return base.nullsLast()
+
+          return dir === 'asc' ? base.nullsFirst() : base.nullsLast()
+        })
       }
       return query
     },
@@ -78,5 +85,5 @@ describe('SQLite pagination helper', () => {
     }
   }
 
-  runSharedTests(createCoercingHelpers, 'sqlite')
+  runSharedTests(createCoercingHelpers, 'sqlite', config.dialect.meta)
 })

--- a/test/dialect/sqlite.test.ts
+++ b/test/dialect/sqlite.test.ts
@@ -10,16 +10,17 @@ describe('SQLite pagination helper', () => {
   let db: Kysely<TestDB>
 
   const config: DatabaseConfig = {
-    dialect: SqlitePaginationDialect,
+    dialect: new SqlitePaginationDialect(),
     createTable: async (db) => {
       await sql`
-        CREATE TABLE users (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          name TEXT NOT NULL,
-          created_at TEXT NOT NULL,
-          rating INTEGER NULL,
-          active INTEGER NOT NULL DEFAULT 1
-        )
+          CREATE TABLE users
+          (
+              id         INTEGER PRIMARY KEY AUTOINCREMENT,
+              name       TEXT    NOT NULL,
+              created_at TEXT    NOT NULL,
+              rating     INTEGER NULL,
+              active     INTEGER NOT NULL DEFAULT 1
+          )
       `.execute(db)
     },
     insertTestData: async (db, rows) => {
@@ -48,8 +49,8 @@ describe('SQLite pagination helper', () => {
 
   beforeAll(async () => {
     const sqlite = new BetterSqlite3(':memory:')
-    const dialect = new SqliteDialect({ database: sqlite })
-    db = new Kysely<TestDB>({ dialect })
+    const dialect = new SqliteDialect({database: sqlite})
+    db = new Kysely<TestDB>({dialect})
 
     await config.createTable(db)
     const testData = createTestData()
@@ -57,12 +58,13 @@ describe('SQLite pagination helper', () => {
   })
 
   afterAll(async () => {
-    await db?.destroy().catch(() => {})
+    await db?.destroy().catch(() => {
+    })
   })
 
   const createCoercingHelpers = () => {
     const base = createTestHelpers(db, config)
-    const coerce = (r: any) => ({ ...r, active: r.active === 1 || r.active === true })
+    const coerce = (r: any) => ({...r, active: r.active === 1 || r.active === true})
     return {
       ...base,
       fetchAllPlainSorted: async (sorts: any) => {
@@ -71,7 +73,7 @@ describe('SQLite pagination helper', () => {
       },
       page: async (limit: number, sorts: any, token?: string) => {
         const res = await base.page(limit, sorts, token)
-        return { ...res, items: res.items.map(coerce) }
+        return {...res, items: res.items.map(coerce)}
       },
     }
   }

--- a/test/dialect/sqlite.test.ts
+++ b/test/dialect/sqlite.test.ts
@@ -42,8 +42,8 @@ describe('SQLite pagination helper', () => {
 
   beforeAll(async () => {
     const sqlite = new BetterSqlite3(':memory:')
-    const dialect = new SqliteDialect({database: sqlite})
-    db = new Kysely<TestDB>({dialect})
+    const dialect = new SqliteDialect({ database: sqlite })
+    db = new Kysely<TestDB>({ dialect })
 
     await config.createTable(db)
     const testData = createTestData()
@@ -51,13 +51,12 @@ describe('SQLite pagination helper', () => {
   })
 
   afterAll(async () => {
-    await db?.destroy().catch(() => {
-    })
+    await db?.destroy().catch(() => {})
   })
 
   const createCoercingHelpers = () => {
     const base = createTestHelpers(db, config)
-    const coerce = (r: any) => ({...r, active: r.active === 1 || r.active === true})
+    const coerce = (r: any) => ({ ...r, active: r.active === 1 || r.active === true })
     return {
       ...base,
       fetchAllPlainSorted: async (sorts: any) => {
@@ -66,7 +65,7 @@ describe('SQLite pagination helper', () => {
       },
       page: async (limit: number, sorts: any, token?: string) => {
         const res = await base.page(limit, sorts, token)
-        return {...res, items: res.items.map(coerce)}
+        return { ...res, items: res.items.map(coerce) }
       },
     }
   }

--- a/test/dialect/sqlite.test.ts
+++ b/test/dialect/sqlite.test.ts
@@ -38,20 +38,6 @@ describe('SQLite pagination helper', () => {
         )
         .execute()
     },
-    applySortToQuery: (query, sorts) => {
-      for (const s of sorts) {
-        const dir = s.dir ?? 'asc'
-        query = query.orderBy(s.col, (o: any) => {
-          const base = dir === 'asc' ? o.asc() : o.desc()
-
-          if (s.nulls === 'first') return base.nullsFirst()
-          if (s.nulls === 'last') return base.nullsLast()
-
-          return dir === 'asc' ? base.nullsFirst() : base.nullsLast()
-        })
-      }
-      return query
-    },
   }
 
   beforeAll(async () => {

--- a/test/pagination.test-d.ts
+++ b/test/pagination.test-d.ts
@@ -1,12 +1,12 @@
 import type { SelectQueryBuilder } from 'kysely'
 
 import type { EdgeOutgoing } from '~/cursor.js'
-
 import { MssqlPaginationDialect } from '~/dialect/mssql.js'
 import { PostgresPaginationDialect } from '~/dialect/postgres.js'
-import { createPaginator } from '../src/index.js'
 import type { SortSet } from '~/sorting.js'
 import type { PaginatedResult, PaginatedResultWithEdges } from '~/types.js'
+
+import { createPaginator } from '../src/index.js'
 
 type UserRow = {
   id: number

--- a/test/pagination.test-d.ts
+++ b/test/pagination.test-d.ts
@@ -50,6 +50,7 @@ const validSortsQualifiedOnly: SortSet<DB, 'users', UserRow> = [
   { col: 'users.created_at', dir: 'asc' },
   { col: 'users.id', dir: 'asc' },
 ]
+
 const validSortsNullsDirective: SortSet<DB, 'users', UserRow> = [
   { col: 'users.created_at', dir: 'asc', nulls: 'last' },
   { col: 'users.id', dir: 'asc' },
@@ -76,7 +77,7 @@ const _badOutputKeyAlias: SortSet<DB, 'users', UserRow> = [
 const _emptySortsDisallowed: SortSet<DB, 'users', UserRow> = []
 
 // @ts-expect-error - no null final sort
-const validSortsNullsDirective: SortSet<DB, 'users', UserRow> = [
+const _badNullsDirectiveFinalSort: SortSet<DB, 'users', UserRow> = [
   { col: 'users.created_at', dir: 'asc', nulls: 'last' },
   { col: 'users.id', dir: 'asc', nulls: 'first' },
 ]
@@ -144,7 +145,6 @@ describe('paginate (type-level)', () => {
 
   it('infers item type via ExtractPaginatedItem helper', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
-
     const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
     const _run = () =>
       paginator.paginate<DB, 'users', UserRow, typeof validSortsAscId>({
@@ -163,6 +163,16 @@ describe('paginate (type-level)', () => {
     await paginator.paginate<DB, 'users', UserRow, typeof validSortsQualifiedOnly>({
       query: builder,
       sorts: validSortsQualifiedOnly,
+      limit: 10,
+    })
+  })
+
+  it('supports nulls directive on non-final sorts', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsNullsDirective>({
+      query: builder,
+      sorts: validSortsNullsDirective,
       limit: 10,
     })
   })

--- a/test/pagination.test-d.ts
+++ b/test/pagination.test-d.ts
@@ -20,7 +20,7 @@ type DB = {
   users: UserRow
 }
 
-function makeBuilder<DB, TB extends keyof DB,O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
+function makeBuilder<DB, TB extends keyof DB, O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
   const self = {
     limit(_: number) {
       return self as unknown as SelectQueryBuilder<DB, TB, O>
@@ -50,6 +50,10 @@ const validSortsQualifiedOnly: SortSet<DB, 'users', UserRow> = [
   { col: 'users.created_at', dir: 'asc' },
   { col: 'users.id', dir: 'asc' },
 ]
+const validSortsNullsDirective: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'asc', nulls: 'last' },
+  { col: 'users.id', dir: 'asc' },
+]
 
 const validSortsWithBigint: SortSet<DB, 'users', UserRow> = [
   { col: 'users.orders_count', output: 'orders_count', dir: 'desc' },
@@ -70,6 +74,12 @@ const _badOutputKeyAlias: SortSet<DB, 'users', UserRow> = [
 
 // @ts-expect-error - empty sorts are disallowed
 const _emptySortsDisallowed: SortSet<DB, 'users', UserRow> = []
+
+// @ts-expect-error - no null final sort
+const validSortsNullsDirective: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'asc', nulls: 'last' },
+  { col: 'users.id', dir: 'asc', nulls: 'first' },
+]
 
 describe('paginate (type-level)', () => {
   it('returns PaginatedResult<O> with correct item type', async () => {

--- a/test/pagination.test-d.ts
+++ b/test/pagination.test-d.ts
@@ -2,11 +2,11 @@ import type { SelectQueryBuilder } from 'kysely'
 
 import type { EdgeOutgoing } from '~/cursor.js'
 
-import { MssqlPaginationDialect } from '../src/dialect/mssql.js'
-import { PostgresPaginationDialect } from '../src/dialect/postgres.js'
+import { MssqlPaginationDialect } from '~/dialect/mssql.js'
+import { PostgresPaginationDialect } from '~/dialect/postgres.js'
 import { createPaginator } from '../src/index.js'
-import type { SortSet } from '../src/sorting.js'
-import type { PaginatedResult, PaginatedResultWithEdges } from '../src/types.js'
+import type { SortSet } from '~/sorting.js'
+import type { PaginatedResult, PaginatedResultWithEdges } from '~/types.js'
 
 type UserRow = {
   id: number
@@ -20,7 +20,7 @@ type DB = {
   users: UserRow
 }
 
-function makeBuilder<DB, TB extends keyof DB, O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
+function makeBuilder<DB, TB extends keyof DB,O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
   const self = {
     limit(_: number) {
       return self as unknown as SelectQueryBuilder<DB, TB, O>
@@ -74,7 +74,7 @@ const _emptySortsDisallowed: SortSet<DB, 'users', UserRow> = []
 describe('paginate (type-level)', () => {
   it('returns PaginatedResult<O> with correct item type', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
-    const paginator = createPaginator({ dialect: PostgresPaginationDialect })
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
     const res = await paginator.paginate<DB, 'users', UserRow, typeof validSortsAscId>({
       query: builder,
       sorts: validSortsAscId,
@@ -87,8 +87,8 @@ describe('paginate (type-level)', () => {
 
   it('accepts both dialects and rejects unknown dialect strings at compile time', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
-    const pgPaginator = createPaginator({ dialect: PostgresPaginationDialect })
-    const msPaginator = createPaginator({ dialect: MssqlPaginationDialect })
+    const pgPaginator = createPaginator({ dialect: new PostgresPaginationDialect() })
+    const msPaginator = createPaginator({ dialect: new MssqlPaginationDialect() })
 
     await pgPaginator.paginate<DB, 'users', UserRow, typeof validSortsQualifiedOnly>({
       query: builder,
@@ -108,7 +108,7 @@ describe('paginate (type-level)', () => {
 
   it('supports nullable leading sorts and enforces non-nullable final sort', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
-    const paginator = createPaginator({ dialect: PostgresPaginationDialect })
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
     await paginator.paginate<DB, 'users', UserRow, typeof validSortsAscId>({
       query: builder,
       sorts: validSortsAscId,
@@ -124,7 +124,7 @@ describe('paginate (type-level)', () => {
 
   it('accepts bigint and other supported sortable value domains', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
-    const paginator = createPaginator({ dialect: MssqlPaginationDialect })
+    const paginator = createPaginator({ dialect: new MssqlPaginationDialect() })
     await paginator.paginate<DB, 'users', UserRow, typeof validSortsWithBigint>({
       query: builder,
       sorts: validSortsWithBigint,
@@ -135,7 +135,7 @@ describe('paginate (type-level)', () => {
   it('infers item type via ExtractPaginatedItem helper', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
 
-    const paginator = createPaginator({ dialect: PostgresPaginationDialect })
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
     const _run = () =>
       paginator.paginate<DB, 'users', UserRow, typeof validSortsAscId>({
         query: builder,
@@ -149,7 +149,7 @@ describe('paginate (type-level)', () => {
 
   it('supports using only qualified col to derive output key', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
-    const paginator = createPaginator({ dialect: PostgresPaginationDialect })
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
     await paginator.paginate<DB, 'users', UserRow, typeof validSortsQualifiedOnly>({
       query: builder,
       sorts: validSortsQualifiedOnly,
@@ -172,7 +172,7 @@ describe('paginate (type-level)', () => {
 describe('paginateWithEdges (type-level)', () => {
   it('returns PaginatedResultWithEdges<O> with correct item type', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
-    const paginator = createPaginator({ dialect: PostgresPaginationDialect })
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
     const res = await paginator.paginateWithEdges<DB, 'users', UserRow, typeof validSortsAscId>({
       query: builder,
       sorts: validSortsAscId,

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -4,7 +4,7 @@ import { base64UrlCodec } from '~/codec/base64Url.js'
 import { codecPipe } from '~/codec/codec.js'
 import { superJsonCodec } from '~/codec/superJson.js'
 import * as cursorModule from '~/cursor.js'
-import { decodeCursor, resolveCursor, sortSignature } from '~/cursor.js'
+import { buildCursorPredicateRecursive, decodeCursor, resolveCursor, sortSignature } from '~/cursor.js'
 import { PaginationError } from '~/error.js'
 import { paginate, paginateWithEdges } from '~/paginator.js'
 import type { SortSet } from '~/sorting.js'
@@ -22,7 +22,7 @@ type DB = {
   users: UserRow
 }
 
-function makeBuilder<DB, TB extends keyof DB,O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
+function makeBuilder<DB, TB extends keyof DB, O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
   const self = {
     // postgres
     limit(_: number) {
@@ -285,5 +285,156 @@ describe('paginateWithEdges (runtime)', () => {
         cursorCodec,
       }),
     ).rejects.toThrow(paginationError)
+  })
+})
+
+describe('null-aware sorting', () => {
+  it('includes nulls directive in sortSignature', () => {
+    const sortsNullsFirst: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'asc', nulls: 'first' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+    const sortsNullsLast: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'asc', nulls: 'last' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    const sigFirst = sortSignature(sortsNullsFirst)
+    const sigLast = sortSignature(sortsNullsLast)
+
+    expect(sigFirst).not.toEqual(sigLast)
+  })
+
+  it('builds predicate for a NULL cursor value when nulls come first', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.name', dir: 'asc', nulls: 'first' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    const decoded = {
+      sig: sortSignature(sorts),
+      k: {
+        name: null,
+        id: 10,
+      },
+    }
+
+    const eb: any = (col: any, op: any, value: any) => ({ type: 'cmp', col, op, value })
+    eb.and = (parts: any[]) => ({ type: 'and', parts })
+    eb.or = (parts: any[]) => ({ type: 'or', parts })
+
+    const predicate = buildCursorPredicateRecursive(eb, sorts, decoded, TestDialect.meta)
+
+    expect(predicate).toMatchObject({
+      type: 'or',
+      parts: [
+        {
+          type: 'and',
+          parts: [
+            {
+              type: 'cmp',
+              col: 'users.name',
+              op: 'is',
+              value: null,
+            },
+            {
+              type: 'or',
+              parts: [
+                {
+                  type: 'and',
+                  parts: [
+                    {
+                      type: 'cmp',
+                      col: 'users.id',
+                      op: 'is not',
+                      value: null,
+                    },
+                    {
+                      type: 'cmp',
+                      col: 'users.id',
+                      op: '>',
+                      value: 10,
+                    },
+                  ],
+                },
+                {
+                  type: 'cmp',
+                  col: 'users.id',
+                  op: 'is',
+                  value: null,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'cmp',
+          col: 'users.name',
+          op: 'is not',
+          value: null,
+        },
+      ],
+    })
+  })
+
+  it('builds predicate for a NULL cursor value when nulls come last', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.name', dir: 'asc', nulls: 'last' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    const decoded = {
+      sig: sortSignature(sorts),
+      k: {
+        name: null,
+        id: 10,
+      },
+    }
+
+    const eb: any = (col: any, op: any, value: any) => ({ type: 'cmp', col, op, value })
+    eb.and = (parts: any[]) => ({ type: 'and', parts })
+    eb.or = (parts: any[]) => ({ type: 'or', parts })
+
+    const predicate = buildCursorPredicateRecursive(eb, sorts, decoded, TestDialect.meta)
+
+    expect(predicate).toMatchObject({
+      type: 'and',
+      parts: [
+        {
+          type: 'cmp',
+          col: 'users.name',
+          op: 'is',
+          value: null,
+        },
+        {
+          type: 'or',
+          parts: [
+            {
+              type: 'and',
+              parts: [
+                {
+                  type: 'cmp',
+                  col: 'users.id',
+                  op: 'is not',
+                  value: null,
+                },
+                {
+                  type: 'cmp',
+                  col: 'users.id',
+                  op: '>',
+                  value: 10,
+                },
+              ],
+            },
+            {
+              type: 'cmp',
+              col: 'users.id',
+              op: 'is',
+              value: null,
+            },
+          ],
+        },
+      ],
+    })
   })
 })

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -115,6 +115,49 @@ describe('paginate (runtime)', () => {
   })
 })
 
+describe('input validation', () => {
+  it('rejects non-integer and non-positive limits as INVALID_LIMIT', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    for (const limit of [0, -1, 2.5, Number.NaN]) {
+      await expect(
+        paginate({
+          query: builder,
+          sorts: validSortsQualifiedOnly,
+          limit,
+          dialect: TestDialect,
+        }),
+      ).rejects.toMatchObject({ code: 'INVALID_LIMIT', message: 'Invalid page size limit' })
+    }
+  })
+
+  it('rejects negative and non-integer offsets as INVALID_TOKEN', async () => {
+    for (const offset of [-1, 1.5, Number.NaN]) {
+      await expect(decodeCursor({ offset }, cursorCodec)).rejects.toMatchObject({
+        code: 'INVALID_TOKEN',
+        message: 'Invalid pagination offset',
+      })
+    }
+  })
+
+  it('accepts zero and positive integer offsets', async () => {
+    await expect(decodeCursor({ offset: 0 }, cursorCodec)).resolves.toEqual({ type: 'offset', offset: 0 })
+    await expect(decodeCursor({ offset: 42 }, cursorCodec)).resolves.toEqual({ type: 'offset', offset: 42 })
+  })
+
+  it('surfaces invalid offsets from paginate as INVALID_TOKEN, not UNEXPECTED_ERROR', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    await expect(
+      paginate({
+        query: builder,
+        sorts: validSortsQualifiedOnly,
+        limit: 5,
+        cursor: { offset: -3 },
+        dialect: TestDialect,
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_TOKEN', message: 'Invalid pagination offset' })
+  })
+})
+
 describe('paginateWithEdges (runtime)', () => {
   it('handles empty result sets (no rows)', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([]) // no rows

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -46,6 +46,10 @@ function makeBuilder<DB, TB extends keyof DB,O>(rows: O[]): SelectQueryBuilder<D
 }
 
 const TestDialect: PaginationDialect = {
+  meta: {
+    supportsNullSortDirective: true,
+    defaultNullsSortAsc: 'last',
+  },
   applyLimit: (builder, limit) => ((builder as any).limit ? (builder as any).limit(limit) : builder),
   applyOffset: (builder) => builder,
   applySort: (builder, sorts) =>

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -22,7 +22,7 @@ type DB = {
   users: UserRow
 }
 
-function makeBuilder<DB, TB extends keyof DB, O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
+function makeBuilder<DB, TB extends keyof DB,O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
   const self = {
     // postgres
     limit(_: number) {

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -4,7 +4,7 @@ import { base64UrlCodec } from '~/codec/base64Url.js'
 import { codecPipe } from '~/codec/codec.js'
 import { superJsonCodec } from '~/codec/superJson.js'
 import * as cursorModule from '~/cursor.js'
-import { buildCursorPredicateRecursive, decodeCursor, resolveCursor, sortSignature } from '~/cursor.js'
+import { buildCursorPredicateRecursive, CURSOR_VERSION, decodeCursor, resolveCursor, sortSignature } from '~/cursor.js'
 import { PaginationError } from '~/error.js'
 import { paginate, paginateWithEdges } from '~/paginator.js'
 import type { SortSet } from '~/sorting.js'
@@ -312,6 +312,7 @@ describe('null-aware sorting', () => {
     ]
 
     const decoded = {
+      v: CURSOR_VERSION,
       sig: sortSignature(sorts),
       k: {
         name: null,
@@ -384,6 +385,7 @@ describe('null-aware sorting', () => {
     ]
 
     const decoded = {
+      v: CURSOR_VERSION,
       sig: sortSignature(sorts),
       k: {
         name: null,
@@ -436,5 +438,78 @@ describe('null-aware sorting', () => {
         },
       ],
     })
+  })
+
+  it('rejects a NULL value on the final sort key', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.name', dir: 'asc', nulls: 'first' },
+      { col: 'users.id', dir: 'asc' },
+    ]
+
+    const decoded = {
+      v: CURSOR_VERSION,
+      sig: sortSignature(sorts),
+      k: {
+        name: 'Alpha',
+        id: null, // final sort must be non-nullable — token is malformed/tampered
+      },
+    }
+
+    const eb: any = (col: any, op: any, value: any) => ({ type: 'cmp', col, op, value })
+    eb.and = (parts: any[]) => ({ type: 'and', parts })
+    eb.or = (parts: any[]) => ({ type: 'or', parts })
+
+    expect(() => buildCursorPredicateRecursive(eb, sorts, decoded, TestDialect.meta)).toThrowError(
+      expect.objectContaining({ code: 'INVALID_TOKEN' }),
+    )
+  })
+})
+
+describe('cursor token hygiene', () => {
+  it('classifies undecodable tokens as INVALID_TOKEN', async () => {
+    await expect(decodeCursor({ nextPage: '!!!not-a-token!!!' }, cursorCodec)).rejects.toMatchObject({
+      code: 'INVALID_TOKEN',
+    })
+  })
+
+  it('classifies decodable but malformed payloads as INVALID_TOKEN', async () => {
+    const token = await cursorCodec.encode({ hello: 'world' })
+    await expect(decodeCursor({ nextPage: token }, cursorCodec)).rejects.toMatchObject({
+      code: 'INVALID_TOKEN',
+      message: 'Invalid page token',
+    })
+  })
+
+  it('rejects tokens from an incompatible cursor version loudly', async () => {
+    const sorts = validSortsQualifiedOnly
+    const payload = { ...resolveCursor({ id: 1, created_at: new Date() } as any, sorts), v: 999 }
+    const token = await cursorCodec.encode(payload)
+
+    await expect(decodeCursor({ nextPage: token }, cursorCodec)).rejects.toMatchObject({
+      code: 'INVALID_TOKEN',
+      message: 'Unsupported cursor version: 999',
+    })
+  })
+
+  it('rejects legacy tokens without a version field', async () => {
+    const sorts = validSortsQualifiedOnly
+    const payload: any = resolveCursor({ id: 1, created_at: new Date() } as any, sorts)
+    delete payload.v // simulate a token minted before versioning existed
+    const token = await cursorCodec.encode(payload)
+
+    await expect(decodeCursor({ nextPage: token }, cursorCodec)).rejects.toMatchObject({
+      code: 'INVALID_TOKEN',
+      message: 'Invalid page token',
+    })
+  })
+
+  it('round-trips payloads including the version field', async () => {
+    const sorts = validSortsQualifiedOnly
+    const payload = resolveCursor({ id: 1, created_at: new Date('2023-01-01T00:00:00Z') } as any, sorts)
+    expect(payload.v).toBe(CURSOR_VERSION)
+
+    const token = await cursorCodec.encode(payload)
+    const decoded = await decodeCursor({ nextPage: token }, cursorCodec)
+    expect(decoded).toMatchObject({ type: 'next', payload: { v: CURSOR_VERSION, sig: payload.sig } })
   })
 })


### PR DESCRIPTION
Adds optional `nulls: 'first' | 'last'` on sort keys, class-based dialects via `BasePaginationDialect`, and null-safe keyset predicates that follow each engine’s default NULL placement. Cursor payloads are versioned; PostgreSQL no longer forces NULLS FIRST/LAST when `nulls` is omitted.