### PR TITLE
Optimize keyset predicates for non-null sorts

### DIFF
--- a/.changeset/keyset-predicate-optimization.md
+++ b/.changeset/keyset-predicate-optimization.md
@@ -1,0 +1,5 @@
+---
+'kysely-cursor': minor
+---
+
+Optimize keyset WHERE emission for non-null sorts: optional `nullable: false` on sort items, dialect-aware plain OR / row-value compare, and `keysetStrategy` (`auto` | `portable`). Default (unmarked) leading sorts stay on the null-safe path.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Cursor‑based (keyset) pagination utilities for [Kysely](https://github.com/kys
     - [Codecs](#codecs)
     - [Null Sorting Behavior](#null-sorting-behavior)
       - [Current behavior](#current-behavior)
-      - [Future plans](#future-plans)
   - [API](#api)
     - [`createPaginator`](#createpaginator)
     - [`paginate` (low-level)](#paginate-low-level)
@@ -61,6 +60,7 @@ yielding:
 
 - **Next/previous** page navigation with automatic sort inversion for `prev`.
 - **Offset fallback** via `cursor: { offset: number }` when you must use numeric offsets.
+- **Optional opt-in** for faster deep-page queries when leading sort keys are non-null (`nullable: false`).
 - **Pluggable codecs** for page tokens: SuperJSON, Base64 URL, AES‑GCM encryption, and external stash storage.
 - **Composable codecs** (`codecPipe`) to build pipelines like `superjson → encrypt → base64url`.
 - **Typed** end‑to‑end with Kysely generics; sort keys map to your selected output.
@@ -149,9 +149,14 @@ const sorts = [
 - Leading sorts take precedence over later sorts.
 - Leading sorts may be nullable; the **final sort must be non-nullable & unique**.
 - Use a primary key or a unique index for the final sort — this acts as a tie-breaker.
+- Prefer a composite index that matches the sort, e.g. `(created_at DESC, id DESC)`.
 - `dir` is the sort direction. Defaults to `asc`.
 - `col` is the field to sort by, optionally qualified.
-- `output` is the field name in your outputted rows. Defaults to `col`, without the qualifying prefix. May need to be explicitly set if your `col` is aliased in your select statement.
+- `output` is the field name in your outputted rows. Defaults to `col`, without the qualifying prefix. May need to be
+  explicitly set if your `col` is aliased in your select statement.
+- `nullable` — for **leading** keys that never contain NULL, set `nullable: false` so the library can use a simpler
+  (usually faster) keyset predicate. Omit it when the column may be null; that is also the default if you leave it out.
+  TypeScript rejects `nullable: false` on columns typed as `| null`, and `nullable: true` on non-null columns.
 - `nulls` is an optional per-sort null ordering hint:
 
   ```ts
@@ -161,7 +166,8 @@ const sorts = [
   - `'first'` → place all `NULL`s before non-NULLs for that sort
   - `'last'` → place all `NULL`s after non-NULLs for that sort
   - If omitted, the dialect’s defaults are used (see below).
-  - On dialects that **don’t** support `NULLS FIRST / LAST` (e.g. MySQL, MSSQL), providing `nulls` will throw a `PaginationError` at runtime — so only specify it when the dialect can express it.
+  - On dialects that **don’t** support `NULLS FIRST / LAST` (e.g. MySQL, MSSQL), providing `nulls` will throw a
+    `PaginationError` at runtime — so only specify it when the dialect can express it.
 
 ### Dialects
 
@@ -171,6 +177,8 @@ Built‑ins (imported from `kysely-cursor`):
 - `MysqlPaginationDialect`
 - `MssqlPaginationDialect`
 - `SqlitePaginationDialect`
+
+Construct with `new` (e.g. `new PostgresPaginationDialect()`). Custom dialects can extend `BasePaginationDialect`.
 
 ### Codecs
 
@@ -411,9 +419,24 @@ The library over‑fetches by `limit+1` to determine if there’s another page. 
 forward; an empty result returns no tokens.
 
 **How are NULLs handled?**
-You can now control this per sort via `nulls: 'first' | 'last'` on dialects that support it. If you omit it, the dialect’s
+You can control this per sort via `nulls: 'first' | 'last'` on dialects that support it. If you omit it, the dialect’s
 declared defaults are used, and descending sorts get the inverse of the ascending default. On dialects that can’t express
 null placement, specifying `nulls` throws an error so you don’t get silent drift.
+
+**When should I set `nullable: false`?**
+When a leading sort column truly has no NULLs (and you have a matching index). That lets the library use a simpler
+predicate for deep pages. Leave it unset if the column can be null — correctness comes first.
+
+**What is `keysetStrategy`?**
+Most apps never need this. Defaults to `auto` (use the best form the dialect supports). Set `portable` only if you want
+to avoid dialect-specific tuple/row comparisons:
+
+```ts
+const paginator = createPaginator({
+  dialect: new PostgresPaginationDialect(),
+  keysetStrategy: 'portable',
+})
+```
 
 ---
 

--- a/src/dialect/base.ts
+++ b/src/dialect/base.ts
@@ -3,9 +3,9 @@ import type { OrderByExpression, SelectQueryBuilder } from 'kysely'
 import { PaginationError } from '~/error.js'
 
 import type { DecodedCursorNextPrev } from '../cursor.js'
-import { buildCursorPredicateRecursive } from '../cursor.js'
+import { emitKeysetPredicate } from '../keyset.js'
 import type { SortSet } from '../sorting.js'
-import type { DialectMeta, PaginationDialect } from '../types.js'
+import type { DialectMeta, KeysetStrategy, PaginationDialect } from '../types.js'
 
 export abstract class BasePaginationDialect implements PaginationDialect {
   abstract meta: DialectMeta
@@ -63,7 +63,8 @@ export abstract class BasePaginationDialect implements PaginationDialect {
     query: SelectQueryBuilder<DB, TB, O>,
     sorts: SortSet<DB, TB, O>,
     cursor: DecodedCursorNextPrev,
+    keysetStrategy: KeysetStrategy = 'auto',
   ): SelectQueryBuilder<DB, TB, O> {
-    return query.where((eb) => buildCursorPredicateRecursive(eb, sorts, cursor.payload, this.meta))
+    return query.where((eb) => emitKeysetPredicate(eb, sorts, cursor.payload, this.meta, keysetStrategy))
   }
 }

--- a/src/dialect/mssql.ts
+++ b/src/dialect/mssql.ts
@@ -9,6 +9,9 @@ export class MssqlPaginationDialect extends BasePaginationDialect {
   meta = {
     supportsNullSortDirective: false,
     defaultNullsSortAsc: 'first' as const,
+    // No portable SQL row-value comparison on MSSQL.
+    supportsRowValueCompare: false,
+    supportsPlainOrKeyset: true,
   }
 
   override applyLimit<DB, TB extends keyof DB, O>(

--- a/src/dialect/mysql.ts
+++ b/src/dialect/mysql.ts
@@ -7,5 +7,9 @@ export class MysqlPaginationDialect extends BasePaginationDialect {
   meta = {
     supportsNullSortDirective: false,
     defaultNullsSortAsc: 'first' as const,
+    // Benches: null-safe OR seeks well; both plain OR and row compare regress badly
+    // at depth when nullable: false opts out of the null-safe tree. Stay on null_safe_or.
+    supportsRowValueCompare: false,
+    supportsPlainOrKeyset: false,
   }
 }

--- a/src/dialect/postgres.ts
+++ b/src/dialect/postgres.ts
@@ -7,5 +7,7 @@ export class PostgresPaginationDialect extends BasePaginationDialect {
   meta = {
     supportsNullSortDirective: true,
     defaultNullsSortAsc: 'last' as const,
+    supportsRowValueCompare: true,
+    supportsPlainOrKeyset: true,
   }
 }

--- a/src/dialect/sqlite.ts
+++ b/src/dialect/sqlite.ts
@@ -7,5 +7,7 @@ export class SqlitePaginationDialect extends BasePaginationDialect {
   meta = {
     supportsNullSortDirective: true,
     defaultNullsSortAsc: 'first' as const,
+    supportsRowValueCompare: true,
+    supportsPlainOrKeyset: true,
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export { ErrorCode, PaginationError } from './error.js'
 // paginator
 export { createPaginator, paginate, paginateWithEdges } from './paginator.js'
 export type {
+  DialectMeta,
+  KeysetStrategy,
   PaginateArgs,
   PaginatedResult,
   PaginatedResultWithEdges,

--- a/src/keyset.ts
+++ b/src/keyset.ts
@@ -1,0 +1,209 @@
+import type { ExpressionBuilder, ExpressionWrapper, ReferenceExpression, SqlBool } from 'kysely'
+import { sql } from 'kysely'
+
+import type { CursorPayload } from './cursor.js'
+import { buildCursorPredicateRecursive, getSortOutput } from './cursor.js'
+import { PaginationError } from './error.js'
+import type { SortSet } from './sorting.js'
+import { applyDefaultDirection } from './sorting.js'
+import type { DialectMeta, KeysetStrategy } from './types.js'
+
+export type KeysetClass =
+  | { kind: 'null_safe' }
+  | {
+      kind: 'simple_non_null'
+      uniformDir: 'asc' | 'desc' | 'mixed'
+    }
+
+export type EmitKind = 'null_safe_or' | 'plain_or' | 'row_compare'
+
+/**
+ * Classify applied sorts + cursor payload for keyset emission.
+ * Run only on **applied** sorts (after prev-page inversion).
+ */
+export const classifyKeyset = (sorts: SortSet<any, any, any>, payload: CursorPayload): KeysetClass => {
+  for (let i = 0; i < sorts.length; i++) {
+    const sort = sorts[i]!
+    const isLast = i === sorts.length - 1
+    const key = getSortOutput(sort)
+
+    if (!(key in payload.k))
+      throw new PaginationError({
+        message: `Missing pagination cursor value for "${key}"`,
+        code: 'INVALID_TOKEN',
+      })
+
+    const value = payload.k[key]
+
+    // Final key must be non-null (unique tie-breaker). Fail loudly.
+    if (isLast && value === null)
+      throw new PaginationError({
+        message: `Pagination cursor has null value for final sort "${key}"`,
+        code: 'INVALID_TOKEN',
+      })
+
+    // Explicit null placement always forces the null-safe path.
+    if (sort.nulls === 'first' || sort.nulls === 'last') return { kind: 'null_safe' }
+
+    // Non-final keys default to nullable unless the caller opts out.
+    if (!isLast) {
+      if (sort.nullable !== false) return { kind: 'null_safe' }
+      // Defensive: a null in the token on a "non-null" leading key falls back
+      // to the null-safe path rather than emitting non-null SQL.
+      if (value === null) return { kind: 'null_safe' }
+    }
+  }
+
+  let uniformDir: 'asc' | 'desc' | 'mixed' | undefined
+  for (const sort of sorts) {
+    const dir = applyDefaultDirection(sort.dir)
+    if (uniformDir === undefined) {
+      uniformDir = dir
+    } else if (uniformDir !== dir) {
+      uniformDir = 'mixed'
+      break
+    }
+  }
+
+  return { kind: 'simple_non_null', uniformDir: uniformDir ?? 'asc' }
+}
+
+/**
+ * Select emission strategy from classification + dialect capability + option.
+ */
+export const selectKeysetStrategy = (
+  class_: KeysetClass,
+  meta: DialectMeta,
+  opt: KeysetStrategy = 'auto',
+): EmitKind => {
+  if (class_.kind === 'null_safe') return 'null_safe_or'
+
+  // `portable` never uses row compare; `auto` prefers it when class + dialect allow.
+  const allowRow = opt !== 'portable' && meta.supportsRowValueCompare && class_.uniformDir !== 'mixed'
+
+  if (allowRow) return 'row_compare'
+
+  // Some engines (MySQL) seek null-safe OR better than classic plain OR at depth.
+  if (meta.supportsPlainOrKeyset === false) return 'null_safe_or'
+
+  return 'plain_or'
+}
+
+/**
+ * Emit a keyset WHERE predicate for the given applied sorts + cursor payload.
+ */
+export const emitKeysetPredicate = <DB, TB extends keyof DB>(
+  eb: ExpressionBuilder<DB, TB>,
+  sorts: SortSet<any, any, any>,
+  payload: CursorPayload,
+  meta: DialectMeta,
+  keysetStrategy: KeysetStrategy = 'auto',
+): ExpressionWrapper<DB, TB, SqlBool> => {
+  const class_ = classifyKeyset(sorts, payload)
+  const kind = selectKeysetStrategy(class_, meta, keysetStrategy)
+
+  switch (kind) {
+    case 'null_safe_or':
+      return buildCursorPredicateRecursive(eb, sorts, payload, meta)
+    case 'plain_or':
+      return buildPlainOrPredicate(eb, sorts, payload)
+    case 'row_compare':
+      // uniformDir is always asc|desc when row_compare is selected
+      return buildRowComparePredicate(
+        eb,
+        sorts,
+        payload,
+        (class_ as { kind: 'simple_non_null'; uniformDir: 'asc' | 'desc' }).uniformDir,
+      )
+  }
+}
+
+/**
+ * Classic multi-column keyset without IS NULL / IS NOT NULL guards.
+ * Equivalent to null-safe OR for non-null data with matching ORDER BY.
+ */
+export const buildPlainOrPredicate = <DB, TB extends keyof DB>(
+  eb: ExpressionBuilder<DB, TB>,
+  sorts: SortSet<any, any, any>,
+  payload: CursorPayload,
+  idx = 0,
+): ExpressionWrapper<DB, TB, SqlBool> => {
+  const sort = sorts[idx]
+  if (!sort) throw new PaginationError({ message: 'Sort index out of bounds', code: 'UNEXPECTED_ERROR' })
+
+  const dir = applyDefaultDirection(sort.dir)
+  const col = sort.col as ReferenceExpression<DB, TB>
+  const key = getSortOutput(sort)
+  if (!(key in payload.k))
+    throw new PaginationError({
+      message: `Missing pagination cursor value for "${key}"`,
+      code: 'INVALID_TOKEN',
+    })
+
+  const value = payload.k[key]
+  const isLast = idx === sorts.length - 1
+  const cmp = dir === 'desc' ? '<' : '>'
+
+  if (isLast && value === null)
+    throw new PaginationError({
+      message: `Pagination cursor has null value for final sort "${key}"`,
+      code: 'INVALID_TOKEN',
+    })
+
+  if (isLast) return eb(col, cmp, value)
+
+  const next = buildPlainOrPredicate(eb, sorts, payload, idx + 1)
+  return eb.or([eb(col, cmp, value), eb.and([eb(col, '=', value), next])])
+}
+
+/**
+ * Row-value comparison: `(c1, c2, …) < ($1, $2, …)` (DESC) or `>` (ASC).
+ * Only valid for uniform direction; caller must gate mixed dirs.
+ */
+export const buildRowComparePredicate = <DB, TB extends keyof DB>(
+  eb: ExpressionBuilder<DB, TB>,
+  sorts: SortSet<any, any, any>,
+  payload: CursorPayload,
+  uniformDir: 'asc' | 'desc',
+): ExpressionWrapper<DB, TB, SqlBool> => {
+  // Validate keys / final non-null up front (same errors as other emitters).
+  for (let i = 0; i < sorts.length; i++) {
+    const sort = sorts[i]!
+    const key = getSortOutput(sort)
+    if (!(key in payload.k))
+      throw new PaginationError({
+        message: `Missing pagination cursor value for "${key}"`,
+        code: 'INVALID_TOKEN',
+      })
+    if (i === sorts.length - 1 && payload.k[key] === null)
+      throw new PaginationError({
+        message: `Pagination cursor has null value for final sort "${key}"`,
+        code: 'INVALID_TOKEN',
+      })
+  }
+
+  // Single-column: row compare degenerates to a plain comparison (no tuple).
+  if (sorts.length === 1) {
+    const sort = sorts[0]!
+    const col = sort.col as ReferenceExpression<DB, TB>
+    const key = getSortOutput(sort)
+    const cmp = uniformDir === 'desc' ? '<' : '>'
+    return eb(col, cmp, payload.k[key])
+  }
+
+  const colExprs = sorts.map((s) => {
+    const col = s.col
+    return typeof col === 'string' ? sql.ref(col) : (col as any)
+  })
+  const valExprs = sorts.map((s) => sql.val(payload.k[getSortOutput(s)]))
+  const op = uniformDir === 'desc' ? '<' : '>'
+
+  // Bound parameters only — no string-concatenated literals.
+  // Cast through ExpressionWrapper so the return type matches other emitters;
+  // RawBuilder is accepted by Kysely's where() the same way.
+  return sql<SqlBool>`(${sql.join(colExprs)}) ${sql.raw(op)} (${sql.join(valExprs)})` as unknown as ExpressionWrapper<
+    DB,
+    TB,
+    SqlBool
+  >
+}

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -21,6 +21,7 @@ export const paginate = async <DB, TB extends keyof DB, O, S extends SortSet<DB,
   cursor,
   dialect,
   cursorCodec = DEFAULT_CURSOR_CODEC,
+  keysetStrategy = 'auto',
 }: PaginateArgs<DB, TB, O, S> & PaginatorOptions): Promise<PaginatedResult<O>> => {
   assertLimitSorts(limit, sorts)
 
@@ -39,7 +40,7 @@ export const paginate = async <DB, TB extends keyof DB, O, S extends SortSet<DB,
         if (decodedCursor.payload.sig !== sig)
           throw new PaginationError({ message: 'Page token does not match sort order', code: 'INVALID_TOKEN' })
 
-        q = dialect.applyCursor(q, sortsApplied, decodedCursor)
+        q = dialect.applyCursor(q, sortsApplied, decodedCursor, keysetStrategy)
       }
     }
 

--- a/src/sorting.ts
+++ b/src/sorting.ts
@@ -7,28 +7,56 @@ type MatchingKeys<Obj, M> = Extract<
   string
 >
 
-type OptionallyQualified<TB, O, Allowed> = TB extends string
-  ? MatchingKeys<O, Allowed> | `${TB}.${MatchingKeys<O, Allowed>}`
-  : never
+type OptionallyQualifiedKey<TB, K extends string> = TB extends string ? K | `${TB}.${K}` : K
 
 export const applyDefaultDirection = (dir: OrderByDirection | undefined | null): OrderByDirection => dir ?? 'asc'
 
 export type NullsDirection = 'first' | 'last'
 
-export type SortItem<DB, TB extends keyof DB, O, Allowed> = {
-  dir?: OrderByDirection
-  nulls?: null extends Allowed ? NullsDirection : undefined
-} & (
-  | {
-      col: ReferenceExpression<DB, TB>
-      output: MatchingKeys<O, Allowed>
-    }
-  | {
-      col: StringReference<DB, TB> & OptionallyQualified<TB, O, Allowed>
-    }
-)
-
 type Sortable = string | number | boolean | Date | bigint
+
+/** True when `T` is `any` (keeps `SortSet<any, …>` assignable for runtime helpers). */
+type IsAny<T> = 0 extends 1 & T ? true : false
+
+/**
+ * Constrain `nullable` to the selected column type in `O`:
+ * null → omit/`true`; non-null → omit/`false`; `any` → `boolean`.
+ * Runtime still treats omit as nullable (null-safe path).
+ */
+type NullableProp<Col> =
+  IsAny<Col> extends true ? { nullable?: boolean } : null extends Col ? { nullable?: true } : { nullable?: false }
+
+type SortItemCommon<Allowed> = {
+  dir?: OrderByDirection
+  /** Only when the column type may be null (leading keys). */
+  nulls?: null extends Allowed ? NullsDirection : undefined
+}
+
+type SortItemWithOutput<
+  DB,
+  TB extends keyof DB,
+  O,
+  Allowed,
+  K extends MatchingKeys<O, Allowed>,
+> = SortItemCommon<Allowed> & {
+  col: ReferenceExpression<DB, TB>
+  output: K
+} & NullableProp<O[K]>
+
+type SortItemFromCol<
+  DB,
+  TB extends keyof DB,
+  O,
+  Allowed,
+  K extends MatchingKeys<O, Allowed>,
+> = SortItemCommon<Allowed> & {
+  col: StringReference<DB, TB> & OptionallyQualifiedKey<TB, K>
+} & NullableProp<O[K]>
+
+/** One sort key; `nullable` is constrained by the selected field type on `O`. */
+export type SortItem<DB, TB extends keyof DB, O, Allowed> = {
+  [K in MatchingKeys<O, Allowed>]: SortItemWithOutput<DB, TB, O, Allowed, K> | SortItemFromCol<DB, TB, O, Allowed, K>
+}[MatchingKeys<O, Allowed>]
 
 export type SortSet<DB, TB extends keyof DB, O> = readonly [
   ...SortItem<DB, TB, O, Sortable | null>[], // nullable leading sorts

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,24 @@ import type { NullsDirection, SortSet } from './sorting.js'
 export type DialectMeta = {
   supportsNullSortDirective: boolean
   defaultNullsSortAsc: NullsDirection
+  /** SQL row-value comparison: (a, b) < ($1, $2) */
+  supportsRowValueCompare: boolean
+  /**
+   * When false, `simple_non_null` sorts stay on the null-safe OR tree instead of
+   * classic plain OR. MySQL's optimizer seeks the null-safe form well but often
+   * walks plain OR / row compare at depth (benches). Defaults to true.
+   */
+  supportsPlainOrKeyset?: boolean
 }
+
+/**
+ * How the library chooses keyset WHERE emission for non-null uniform sorts.
+ *
+ * - `auto` (default): row compare when the dialect supports it and sorts allow;
+ *   otherwise plain multi-column OR. Nullable / null-ordered sorts stay null-safe.
+ * - `portable`: never emit row compare (only null-safe OR / plain OR).
+ */
+export type KeysetStrategy = 'auto' | 'portable'
 
 export type PaginationDialect = {
   meta: DialectMeta
@@ -32,6 +49,7 @@ export type PaginationDialect = {
     query: SelectQueryBuilder<DB, TB, O>,
     sorts: SortSet<DB, TB, O>,
     cursor: DecodedCursorNextPrev,
+    keysetStrategy?: KeysetStrategy,
   ) => SelectQueryBuilder<DB, TB, O>
 }
 
@@ -41,6 +59,11 @@ export type PaginatorOptions = {
    * Defaults to superJson & base64Url
    */
   cursorCodec?: Codec<any, string>
+  /**
+   * Keyset WHERE emission preference. Defaults to `auto`.
+   * See {@link KeysetStrategy}.
+   */
+  keysetStrategy?: KeysetStrategy
 }
 
 export type PaginateArgs<DB, TB extends keyof DB, O, S extends SortSet<DB, TB, O>> = {

--- a/test/dialect/mysql.test.ts
+++ b/test/dialect/mysql.test.ts
@@ -55,7 +55,10 @@ describe('MySQL pagination helper', () => {
       },
     })
 
-    const dialect = new MysqlDialect({ pool })
+    // mysql2 Pool typings have drifted relative to Kysely's MysqlPool across
+    // 0.28.x (strict structural match fails on older Kysely + newer mysql2).
+    // Runtime shape is fine; cast keeps the compatibility matrix green.
+    const dialect = new MysqlDialect({ pool: pool as any })
     db = new Kysely<TestDB>({ dialect })
 
     await config.createTable(db)

--- a/test/dialect/shared.ts
+++ b/test/dialect/shared.ts
@@ -132,7 +132,15 @@ export const createTestHelpers = (db: Kysely<TestDB>, config: DatabaseConfig) =>
     await db.deleteFrom('users').where('name', 'in', names).execute()
   }
 
-  return { baseBuilder, deleteRowsByName, fetchAllPlainSorted, insertRow, paginator, page }
+  return {
+    baseBuilder,
+    deleteRowsByName,
+    dialect: config.dialect,
+    fetchAllPlainSorted,
+    insertRow,
+    paginator,
+    page,
+  }
 }
 
 export const resolveNextPageToken = async (items: TestRow[], sorts: SortSet<TestDB, 'users', TestRow>) => {
@@ -742,6 +750,106 @@ export const runSharedTests = (
       seen.push(...res.items)
       token = res.nextPage
     } while (token)
+    expect(seen.map((r) => r.id)).toEqual(expected.map((r) => r.id))
+  })
+
+  // ── keyset predicate optimization (nullable: false → plain OR / row compare) ──
+
+  it('paginates non-null marked uniform sorts equivalently to the default path', async () => {
+    const { baseBuilder, fetchAllPlainSorted, paginator } = createHelpers()
+
+    // Same logical order as the unmarked default; nullable: false opts into the
+    // fast emission path (plain OR / row compare depending on dialect).
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const expected = await fetchAllPlainSorted(sorts)
+    const limit = 4
+
+    const forwardPages: TestRow[][] = []
+    let nextToken: string | undefined
+    let lastPrevToken: string | undefined
+    do {
+      const res = await paginator.paginate({
+        query: baseBuilder(),
+        sorts,
+        limit,
+        cursor: nextToken ? { nextPage: nextToken } : undefined,
+      })
+      forwardPages.push(res.items)
+      nextToken = res.nextPage
+      lastPrevToken = res.prevPage
+    } while (nextToken)
+
+    expect(forwardPages.flat().map((r) => r.id)).toEqual(expected.map((r) => r.id))
+
+    // prev-page uses inverted applied sorts — classifier + strategy must still match
+    const backwardPages: TestRow[][] = []
+    let prevToken = lastPrevToken
+    while (prevToken) {
+      const res = await paginator.paginate({
+        query: baseBuilder(),
+        sorts,
+        limit,
+        cursor: { prevPage: prevToken },
+      })
+      backwardPages.push(res.items)
+      prevToken = res.prevPage
+    }
+    expect(backwardPages.map((p) => p.map((r) => r.id))).toEqual(
+      forwardPages
+        .slice(0, -1)
+        .reverse()
+        .map((p) => p.map((r) => r.id)),
+    )
+  })
+
+  it('paginates non-null marked mixed-direction sorts (never row compare)', async () => {
+    const { fetchAllPlainSorted, page } = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'asc' },
+    ]
+    const expected = await fetchAllPlainSorted(sorts)
+    const seen: TestRow[] = []
+    let token: string | undefined
+    do {
+      const res = await page(3, sorts, token)
+      seen.push(...res.items)
+      token = res.nextPage
+    } while (token)
+    expect(seen.map((r) => r.id)).toEqual(expected.map((r) => r.id))
+  })
+
+  it('honors keysetStrategy portable for non-null marked sorts', async () => {
+    const { baseBuilder, dialect, fetchAllPlainSorted } = createHelpers()
+    const sorts: SortSet<TestDB, 'users', TestRow> = [
+      { col: 'users.created_at', dir: 'asc', nullable: false },
+      { col: 'users.id', dir: 'asc' },
+    ]
+    const expected = await fetchAllPlainSorted(sorts)
+
+    // portable forces plain OR even on dialects that support row compare
+    const portable = createPaginator({
+      dialect,
+      cursorCodec: codecPipe(superJsonCodec, base64UrlCodec),
+      keysetStrategy: 'portable',
+    })
+
+    const seen: TestRow[] = []
+    let token: string | undefined
+    do {
+      const res = await portable.paginate({
+        query: baseBuilder(),
+        sorts,
+        limit: 4,
+        cursor: token ? { nextPage: token } : undefined,
+      })
+      seen.push(...res.items)
+      token = res.nextPage
+    } while (token)
+
     expect(seen.map((r) => r.id)).toEqual(expected.map((r) => r.id))
   })
 

--- a/test/keyset.test.ts
+++ b/test/keyset.test.ts
@@ -1,0 +1,403 @@
+import { CURSOR_VERSION, sortSignature } from '~/cursor.js'
+import {
+  buildPlainOrPredicate,
+  buildRowComparePredicate,
+  classifyKeyset,
+  emitKeysetPredicate,
+  type EmitKind,
+  type KeysetClass,
+  selectKeysetStrategy,
+} from '~/keyset.js'
+import type { SortSet } from '~/sorting.js'
+import type { DialectMeta, KeysetStrategy } from '~/types.js'
+
+type UserRow = {
+  id: number
+  name: string | null
+  created_at: Date
+}
+
+type DB = {
+  users: UserRow
+}
+
+const pgMeta: DialectMeta = {
+  supportsNullSortDirective: true,
+  defaultNullsSortAsc: 'last',
+  supportsRowValueCompare: true,
+}
+
+const mssqlMeta: DialectMeta = {
+  supportsNullSortDirective: false,
+  defaultNullsSortAsc: 'first',
+  supportsRowValueCompare: false,
+  supportsPlainOrKeyset: true,
+}
+
+const mysqlMeta: DialectMeta = {
+  supportsNullSortDirective: false,
+  defaultNullsSortAsc: 'first',
+  supportsRowValueCompare: false,
+  supportsPlainOrKeyset: false,
+}
+
+const makeEb = () => {
+  const eb: any = (col: any, op: any, value: any) => ({ type: 'cmp', col, op, value })
+  eb.and = (parts: any[]) => ({ type: 'and', parts })
+  eb.or = (parts: any[]) => ({ type: 'or', parts })
+  return eb
+}
+
+const payloadFor = (sorts: SortSet<DB, 'users', UserRow>, k: Record<string, unknown>) => ({
+  v: CURSOR_VERSION,
+  sig: sortSignature(sorts),
+  k,
+})
+
+describe('classifyKeyset', () => {
+  it('defaults leading sorts to null_safe when nullable is omitted', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc' },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const payload = payloadFor(sorts, {
+      created_at: new Date('2023-01-01'),
+      id: 10,
+    })
+
+    expect(classifyKeyset(sorts, payload)).toEqual({ kind: 'null_safe' })
+  })
+
+  it('classifies simple_non_null when all non-final sorts set nullable: false', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const payload = payloadFor(sorts, {
+      created_at: new Date('2023-01-01'),
+      id: 10,
+    })
+
+    expect(classifyKeyset(sorts, payload)).toEqual({
+      kind: 'simple_non_null',
+      uniformDir: 'desc',
+    })
+  })
+
+  it('detects uniform ASC and mixed directions', () => {
+    const asc: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'asc', nullable: false },
+      { col: 'users.id', dir: 'asc' },
+    ]
+    const mixed: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'asc' },
+    ]
+    const k = { created_at: new Date('2023-01-01'), id: 1 }
+
+    expect(classifyKeyset(asc, payloadFor(asc, k))).toEqual({
+      kind: 'simple_non_null',
+      uniformDir: 'asc',
+    })
+    expect(classifyKeyset(mixed, payloadFor(mixed, k))).toEqual({
+      kind: 'simple_non_null',
+      uniformDir: 'mixed',
+    })
+  })
+
+  it('forces null_safe when any sort has explicit nulls, even with nullable: false', () => {
+    // Intentional misconfig vs row types: name is string | null, but runtime may still
+    // see nullable: false + nulls and must force the null-safe path.
+    const sorts = [
+      { col: 'users.name', dir: 'asc', nullable: false, nulls: 'last' },
+      { col: 'users.id', dir: 'asc' },
+    ] as unknown as SortSet<DB, 'users', UserRow>
+    const payload = payloadFor(sorts, { name: 'A', id: 1 })
+
+    expect(classifyKeyset(sorts, payload)).toEqual({ kind: 'null_safe' })
+  })
+
+  it('forces null_safe when a non-final cursor value is null', () => {
+    // Intentional misconfig: nullable: false on a nullable-typed column with a null cursor value.
+    const sorts = [
+      { col: 'users.name', dir: 'asc', nullable: false },
+      { col: 'users.id', dir: 'asc' },
+    ] as unknown as SortSet<DB, 'users', UserRow>
+    const payload = payloadFor(sorts, { name: null, id: 1 })
+
+    expect(classifyKeyset(sorts, payload)).toEqual({ kind: 'null_safe' })
+  })
+
+  it('rejects a null final cursor value as INVALID_TOKEN', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const payload = payloadFor(sorts, {
+      created_at: new Date('2023-01-01'),
+      id: null,
+    })
+
+    expect(() => classifyKeyset(sorts, payload)).toThrowError(expect.objectContaining({ code: 'INVALID_TOKEN' }))
+  })
+
+  it('rejects a missing cursor key as INVALID_TOKEN', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const payload = payloadFor(sorts, { created_at: new Date('2023-01-01') })
+
+    expect(() => classifyKeyset(sorts, payload)).toThrowError(expect.objectContaining({ code: 'INVALID_TOKEN' }))
+  })
+})
+
+describe('selectKeysetStrategy', () => {
+  const simpleDesc: KeysetClass = { kind: 'simple_non_null', uniformDir: 'desc' }
+  const simpleMixed: KeysetClass = { kind: 'simple_non_null', uniformDir: 'mixed' }
+  const nullSafe: KeysetClass = { kind: 'null_safe' }
+
+  const cases: Array<{
+    name: string
+    class_: KeysetClass
+    meta: DialectMeta
+    opt?: KeysetStrategy
+    expected: EmitKind
+  }> = [
+    { name: 'null_safe always → null_safe_or', class_: nullSafe, meta: pgMeta, expected: 'null_safe_or' },
+    {
+      name: 'auto + pg + uniform → row_compare',
+      class_: simpleDesc,
+      meta: pgMeta,
+      opt: 'auto',
+      expected: 'row_compare',
+    },
+    {
+      name: 'portable never row_compare',
+      class_: simpleDesc,
+      meta: pgMeta,
+      opt: 'portable',
+      expected: 'plain_or',
+    },
+    {
+      name: 'mixed dir never row_compare',
+      class_: simpleMixed,
+      meta: pgMeta,
+      expected: 'plain_or',
+    },
+    {
+      name: 'mssql never row_compare',
+      class_: simpleDesc,
+      meta: mssqlMeta,
+      expected: 'plain_or',
+    },
+    {
+      name: 'mysql stays on null_safe_or even for simple_non_null',
+      class_: simpleDesc,
+      meta: mysqlMeta,
+      opt: 'auto',
+      expected: 'null_safe_or',
+    },
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      expect(selectKeysetStrategy(c.class_, c.meta, c.opt)).toBe(c.expected)
+    })
+  }
+})
+
+describe('buildPlainOrPredicate', () => {
+  it('emits classic multi-column OR without null guards (DESC)', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const createdAt = new Date('2023-01-01')
+    const payload = payloadFor(sorts, { created_at: createdAt, id: 42 })
+    const eb = makeEb()
+
+    const predicate = buildPlainOrPredicate(eb, sorts, payload)
+
+    expect(predicate).toMatchObject({
+      type: 'or',
+      parts: [
+        { type: 'cmp', col: 'users.created_at', op: '<', value: createdAt },
+        {
+          type: 'and',
+          parts: [
+            { type: 'cmp', col: 'users.created_at', op: '=', value: createdAt },
+            { type: 'cmp', col: 'users.id', op: '<', value: 42 },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('emits classic multi-column OR without null guards (ASC)', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'asc', nullable: false },
+      { col: 'users.id', dir: 'asc' },
+    ]
+    const createdAt = new Date('2023-01-01')
+    const payload = payloadFor(sorts, { created_at: createdAt, id: 42 })
+    const eb = makeEb()
+
+    const predicate = buildPlainOrPredicate(eb, sorts, payload)
+
+    expect(predicate).toMatchObject({
+      type: 'or',
+      parts: [
+        { type: 'cmp', col: 'users.created_at', op: '>', value: createdAt },
+        {
+          type: 'and',
+          parts: [
+            { type: 'cmp', col: 'users.created_at', op: '=', value: createdAt },
+            { type: 'cmp', col: 'users.id', op: '>', value: 42 },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('single-column degenerates to a plain comparison', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [{ col: 'users.id', dir: 'desc' }]
+    const payload = payloadFor(sorts, { id: 7 })
+    const eb = makeEb()
+
+    expect(buildPlainOrPredicate(eb, sorts, payload)).toMatchObject({
+      type: 'cmp',
+      col: 'users.id',
+      op: '<',
+      value: 7,
+    })
+  })
+})
+
+describe('buildRowComparePredicate', () => {
+  it('single-column degenerates to a plain comparison', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [{ col: 'users.id', dir: 'desc' }]
+    const payload = payloadFor(sorts, { id: 7 })
+    const eb = makeEb()
+
+    expect(buildRowComparePredicate(eb, sorts, payload, 'desc')).toMatchObject({
+      type: 'cmp',
+      col: 'users.id',
+      op: '<',
+      value: 7,
+    })
+    expect(buildRowComparePredicate(eb, sorts, payload, 'asc')).toMatchObject({
+      type: 'cmp',
+      col: 'users.id',
+      op: '>',
+      value: 7,
+    })
+  })
+
+  it('rejects null final and missing keys', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const eb = makeEb()
+
+    expect(() =>
+      buildRowComparePredicate(eb, sorts, payloadFor(sorts, { created_at: new Date(), id: null }), 'desc'),
+    ).toThrowError(expect.objectContaining({ code: 'INVALID_TOKEN' }))
+
+    expect(() =>
+      buildRowComparePredicate(eb, sorts, payloadFor(sorts, { created_at: new Date() }), 'desc'),
+    ).toThrowError(expect.objectContaining({ code: 'INVALID_TOKEN' }))
+  })
+
+  it('returns a SQL fragment for multi-column uniform sorts', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const payload = payloadFor(sorts, { created_at: new Date('2023-01-01'), id: 42 })
+    const eb = makeEb()
+
+    // Multi-column path uses kysely `sql` (not the mock eb tree).
+    const predicate = buildRowComparePredicate(eb, sorts, payload, 'desc')
+    expect(predicate).toBeTruthy()
+    expect(typeof (predicate as any).toOperationNode).toBe('function')
+  })
+})
+
+describe('emitKeysetPredicate', () => {
+  it('uses null_safe path by default (unmarked leading sort)', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc' },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const createdAt = new Date('2023-01-01')
+    const payload = payloadFor(sorts, { created_at: createdAt, id: 42 })
+    const eb = makeEb()
+
+    const predicate = emitKeysetPredicate(eb, sorts, payload, pgMeta, 'auto')
+
+    // null-safe form includes IS NOT NULL guards on the leading advance branch
+    expect(predicate).toMatchObject({ type: 'or' })
+    const json = JSON.stringify(predicate)
+    expect(json).toContain('"is not"')
+    expect(json).toContain('"users.created_at"')
+  })
+
+  it('uses plain_or when portable + nullable: false', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const createdAt = new Date('2023-01-01')
+    const payload = payloadFor(sorts, { created_at: createdAt, id: 42 })
+    const eb = makeEb()
+
+    const predicate = emitKeysetPredicate(eb, sorts, payload, pgMeta, 'portable')
+
+    expect(predicate).toEqual(buildPlainOrPredicate(eb, sorts, payload))
+    // no IS NOT NULL in the plain path
+    const json = JSON.stringify(predicate)
+    expect(json).not.toContain('"is not"')
+    expect(json).not.toContain('"is"')
+  })
+
+  it('uses plain_or for mixed directions even when dialect supports row compare', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'asc' },
+    ]
+    const createdAt = new Date('2023-01-01')
+    const payload = payloadFor(sorts, { created_at: createdAt, id: 42 })
+    const eb = makeEb()
+
+    const predicate = emitKeysetPredicate(eb, sorts, payload, pgMeta, 'auto')
+
+    expect(predicate).toMatchObject({
+      type: 'or',
+      parts: [
+        { type: 'cmp', col: 'users.created_at', op: '<', value: createdAt },
+        {
+          type: 'and',
+          parts: [
+            { type: 'cmp', col: 'users.created_at', op: '=', value: createdAt },
+            { type: 'cmp', col: 'users.id', op: '>', value: 42 },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('selects row_compare for auto + supporting dialect + uniform non-null sorts', () => {
+    const sorts: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.id', dir: 'desc' },
+    ]
+    const payload = payloadFor(sorts, { created_at: new Date('2023-01-01'), id: 42 })
+    const eb = makeEb()
+
+    const predicate = emitKeysetPredicate(eb, sorts, payload, pgMeta, 'auto')
+    // row compare is a RawBuilder, not the mock OR tree
+    expect(typeof (predicate as any).toOperationNode).toBe('function')
+  })
+})

--- a/test/pagination.test-d.ts
+++ b/test/pagination.test-d.ts
@@ -1,4 +1,5 @@
 import type { SelectQueryBuilder } from 'kysely'
+import { sql } from 'kysely'
 
 import type { EdgeOutgoing } from '~/cursor.js'
 import { MssqlPaginationDialect } from '~/dialect/mssql.js'
@@ -14,10 +15,18 @@ type UserRow = {
   created_at: Date
   is_active: boolean
   orders_count: bigint
+  rating: number | null
 }
 
 type DB = {
   users: UserRow
+}
+
+/** Projected/joined result where nullability follows aliases, not table columns. */
+type ProjectedRow = {
+  display_name: string | null
+  feed_at: Date
+  id: number
 }
 
 function makeBuilder<DB, TB extends keyof DB, O>(rows: O[]): SelectQueryBuilder<DB, TB, O> {
@@ -61,10 +70,166 @@ const validSortsWithBigint: SortSet<DB, 'users', UserRow> = [
   { col: 'users.id', output: 'id', dir: 'asc' },
 ]
 
+const validSortsNullableFalseOnNonNull: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', nullable: false },
+  { col: 'users.id', dir: 'desc' },
+]
+
+const validSortsNullableTrueOnNullable: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.name', dir: 'asc', nullable: true },
+  { col: 'users.id', dir: 'desc' },
+]
+
+/** Explicit: omit on a nullable leading column is allowed (runtime → null-safe). */
+const validSortsOmitOnNullable: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.name', dir: 'asc' },
+  { col: 'users.id', dir: 'desc' },
+]
+
+/** Explicit: omit on a non-null leading column is allowed (runtime still null-safe until false). */
+const validSortsOmitOnNonNull: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc' },
+  { col: 'users.id', dir: 'desc' },
+]
+
+/** Unqualified col names (single-table style). */
+const validSortsUnqualified: SortSet<DB, 'users', UserRow> = [
+  { col: 'name', dir: 'asc', nullable: true },
+  { col: 'created_at', dir: 'desc', nullable: false },
+  { col: 'id', dir: 'desc' },
+]
+
+/** Multi-leading mix: non-null, nullable, non-null final — correct flags. */
+const validSortsThreeKeyMix: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', nullable: false },
+  { col: 'users.rating', dir: 'desc', nullable: true },
+  { col: 'users.id', dir: 'desc' },
+]
+
+/** Final key may omit or set nullable: false (column is already required non-null). */
+const validSortsFinalNullableFalse: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', nullable: false },
+  { col: 'users.id', dir: 'desc', nullable: false },
+]
+
+/** Expression col + output: nullability follows O[output]. */
+const validSortsExpressionOutput: SortSet<DB, 'users', UserRow> = [
+  { col: sql`lower(name)`, output: 'name', dir: 'asc', nullable: true },
+  { col: sql`id`, output: 'id', dir: 'desc' },
+]
+
+/** Projected row: flags follow projected field types, not table columns. */
+const validSortsProjected: SortSet<DB, 'users', ProjectedRow> = [
+  { col: sql`users.name`, output: 'display_name', dir: 'asc', nullable: true },
+  { col: sql`users.created_at`, output: 'feed_at', dir: 'desc', nullable: false },
+  { col: sql`users.id`, output: 'id', dir: 'desc' },
+]
+
+// Concrete SortSets remain assignable into the erased runtime form used by helpers.
+const _erasedRuntimeSorts: SortSet<any, any, any> = validSortsNullableFalseOnNonNull
+const _erasedRuntimeNullable: SortSet<any, any, any> = validSortsNullableTrueOnNullable
+const _erasedRuntimeThreeKey: SortSet<any, any, any> = validSortsThreeKeyMix
+
 // @ts-expect-error - last sort must be non-nullable sortable
 const _badLastNullable: SortSet<DB, 'users', UserRow> = [
   { col: 'users.id', output: 'id', dir: 'asc' },
   { col: 'users.name', output: 'name', dir: 'asc' },
+]
+
+// @ts-expect-error - nullable: false is not allowed on a nullable column (name)
+const _badNullableFalseOnNullableCol: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.name', dir: 'asc', nullable: false },
+  { col: 'users.id', dir: 'desc' },
+]
+
+// @ts-expect-error - nullable: false is not allowed on a nullable column (via output)
+const _badNullableFalseOnNullableOutput: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.name', output: 'name', nullable: false },
+  { col: 'users.id', dir: 'desc' },
+]
+
+// @ts-expect-error - nullable: true is not allowed on a non-null column (created_at)
+const _badNullableTrueOnNonNullCol: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', nullable: true },
+  { col: 'users.id', dir: 'desc' },
+]
+
+// @ts-expect-error - nullable: true is not allowed on a non-null column (via output)
+const _badNullableTrueOnNonNullOutput: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', output: 'created_at', nullable: true },
+  { col: 'users.id', dir: 'desc' },
+]
+
+// @ts-expect-error - unqualified: nullable: false on nullable name
+const _badUnqualifiedNullableFalse: SortSet<DB, 'users', UserRow> = [
+  { col: 'name', dir: 'asc', nullable: false },
+  { col: 'id', dir: 'desc' },
+]
+
+// @ts-expect-error - unqualified: nullable: true on non-null created_at
+const _badUnqualifiedNullableTrue: SortSet<DB, 'users', UserRow> = [
+  { col: 'created_at', dir: 'desc', nullable: true },
+  { col: 'id', dir: 'desc' },
+]
+
+// @ts-expect-error - three-key mix: wrong flag only on middle nullable key
+const _badThreeKeyMiddleFalse: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', nullable: false },
+  { col: 'users.rating', dir: 'desc', nullable: false },
+  { col: 'users.id', dir: 'desc' },
+]
+
+// @ts-expect-error - three-key mix: wrong flag only on leading non-null key
+const _badThreeKeyLeadingTrue: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', nullable: true },
+  { col: 'users.rating', dir: 'desc', nullable: true },
+  { col: 'users.id', dir: 'desc' },
+]
+
+// @ts-expect-error - final key is non-null; nullable: true is not allowed
+const _badFinalNullableTrue: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', nullable: false },
+  { col: 'users.id', dir: 'desc', nullable: true },
+]
+
+// @ts-expect-error - expression+output: false on nullable O[output]
+const _badExpressionOutputFalse: SortSet<DB, 'users', UserRow> = [
+  { col: sql`lower(name)`, output: 'name', dir: 'asc', nullable: false },
+  { col: sql`id`, output: 'id', dir: 'desc' },
+]
+
+// @ts-expect-error - expression+output: true on non-null O[output]
+const _badExpressionOutputTrue: SortSet<DB, 'users', UserRow> = [
+  { col: sql`created_at`, output: 'created_at', dir: 'desc', nullable: true },
+  { col: sql`id`, output: 'id', dir: 'desc' },
+]
+
+// @ts-expect-error - projected O: false on nullable display_name
+const _badProjectedFalse: SortSet<DB, 'users', ProjectedRow> = [
+  { col: sql`users.name`, output: 'display_name', nullable: false },
+  { col: sql`users.id`, output: 'id' },
+]
+
+// @ts-expect-error - projected O: true on non-null feed_at
+const _badProjectedTrue: SortSet<DB, 'users', ProjectedRow> = [
+  { col: sql`users.created_at`, output: 'feed_at', nullable: true },
+  { col: sql`users.id`, output: 'id' },
+]
+
+// Widened `boolean` (not a true/false literal) is rejected once constrained to true|false.
+// Use `declare` so the binding is not narrowed by a literal initializer.
+declare const _widenedFalse: boolean
+// @ts-expect-error - boolean is not assignable to literal false on non-null column
+const _badWidenedBooleanOnNonNull: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', nullable: _widenedFalse },
+  { col: 'users.id', dir: 'desc' },
+]
+
+declare const _widenedTrue: boolean
+// @ts-expect-error - boolean is not assignable to literal true on nullable column
+const _badWidenedBooleanOnNullable: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.name', dir: 'asc', nullable: _widenedTrue },
+  { col: 'users.id', dir: 'desc' },
 ]
 
 // @ts-expect-error - "nope" is not a key of UserRow
@@ -173,6 +338,143 @@ describe('paginate (type-level)', () => {
     await paginator.paginate<DB, 'users', UserRow, typeof validSortsNullsDirective>({
       query: builder,
       sorts: validSortsNullsDirective,
+      limit: 10,
+    })
+  })
+
+  it('accepts matching nullable flags (omit, true, false) across SortSet shapes', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
+
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsNullableFalseOnNonNull>({
+      query: builder,
+      sorts: validSortsNullableFalseOnNonNull,
+      limit: 10,
+    })
+
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsNullableTrueOnNullable>({
+      query: builder,
+      sorts: validSortsNullableTrueOnNullable,
+      limit: 10,
+    })
+
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsOmitOnNullable>({
+      query: builder,
+      sorts: validSortsOmitOnNullable,
+      limit: 10,
+    })
+
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsOmitOnNonNull>({
+      query: builder,
+      sorts: validSortsOmitOnNonNull,
+      limit: 10,
+    })
+
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsUnqualified>({
+      query: builder,
+      sorts: validSortsUnqualified,
+      limit: 10,
+    })
+
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsThreeKeyMix>({
+      query: builder,
+      sorts: validSortsThreeKeyMix,
+      limit: 10,
+    })
+
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsFinalNullableFalse>({
+      query: builder,
+      sorts: validSortsFinalNullableFalse,
+      limit: 10,
+    })
+
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsExpressionOutput>({
+      query: builder,
+      sorts: validSortsExpressionOutput,
+      limit: 10,
+    })
+
+    const projectedBuilder = makeBuilder<DB, 'users', ProjectedRow>([])
+    await paginator.paginate<DB, 'users', ProjectedRow, typeof validSortsProjected>({
+      query: projectedBuilder,
+      sorts: validSortsProjected,
+      limit: 10,
+    })
+  })
+
+  it('rejects nullable mismatches on inline paginate sorts (user DX path)', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
+
+    // Inline omit on non-null — valid (no cast needed when S is inferred from the literal).
+    await paginator.paginate({
+      query: builder,
+      sorts: [
+        { col: 'users.created_at', dir: 'desc' },
+        { col: 'users.id', dir: 'desc' },
+      ],
+      limit: 10,
+    })
+
+    // Inline omit on nullable — valid.
+    await paginator.paginate({
+      query: builder,
+      sorts: [
+        { col: 'users.name', dir: 'asc' },
+        { col: 'users.id', dir: 'desc' },
+      ],
+      limit: 10,
+    })
+
+    // Inline matching flags — valid.
+    await paginator.paginate({
+      query: builder,
+      sorts: [
+        { col: 'users.created_at', dir: 'desc', nullable: false },
+        { col: 'users.name', dir: 'asc', nullable: true },
+        { col: 'users.id', dir: 'desc' },
+      ],
+      limit: 10,
+    })
+
+    await paginator.paginate({
+      query: builder,
+      // @ts-expect-error - inline: nullable: false on nullable name
+      sorts: [
+        { col: 'users.name', dir: 'asc', nullable: false },
+        { col: 'users.id', dir: 'desc' },
+      ],
+      limit: 10,
+    })
+
+    await paginator.paginate({
+      query: builder,
+      // @ts-expect-error - inline: nullable: true on non-null created_at
+      sorts: [
+        { col: 'users.created_at', dir: 'desc', nullable: true },
+        { col: 'users.id', dir: 'desc' },
+      ],
+      limit: 10,
+    })
+
+    await paginator.paginate({
+      query: builder,
+      // @ts-expect-error - inline: wrong flag on middle key of a three-key sort
+      sorts: [
+        { col: 'users.created_at', dir: 'desc', nullable: false },
+        { col: 'users.rating', dir: 'desc', nullable: false },
+        { col: 'users.id', dir: 'desc' },
+      ],
+      limit: 10,
+    })
+
+    await paginator.paginateWithEdges({
+      query: builder,
+      // @ts-expect-error - inline edges path: nullable: false on nullable name
+      sorts: [
+        { col: 'users.name', dir: 'asc', nullable: false },
+        { col: 'users.id', dir: 'desc' },
+      ],
       limit: 10,
     })
   })

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -49,6 +49,7 @@ const TestDialect: PaginationDialect = {
   meta: {
     supportsNullSortDirective: true,
     defaultNullsSortAsc: 'last',
+    supportsRowValueCompare: true,
   },
   applyLimit: (builder, limit) => ((builder as any).limit ? (builder as any).limit(limit) : builder),
   applyOffset: (builder) => builder,
@@ -341,11 +342,18 @@ describe('null-aware sorting', () => {
       { col: 'users.created_at', dir: 'asc', nulls: 'last' },
       { col: 'users.id', dir: 'asc' },
     ]
+    const sortsOmitted: SortSet<DB, 'users', UserRow> = [
+      { col: 'users.created_at', dir: 'asc' },
+      { col: 'users.id', dir: 'asc' },
+    ]
 
     const sigFirst = sortSignature(sortsNullsFirst)
     const sigLast = sortSignature(sortsNullsLast)
+    const sigOmitted = sortSignature(sortsOmitted)
 
     expect(sigFirst).not.toEqual(sigLast)
+    expect(sigOmitted).not.toEqual(sigFirst)
+    expect(sigOmitted).not.toEqual(sigLast)
   })
 
   it('builds predicate for a NULL cursor value when nulls come first', () => {


### PR DESCRIPTION
Adds optional `nullable: false` on sort keys, dialect-aware plain OR / row-value compare, and `keysetStrategy` (`auto` | `portable`). Defaults stay null-safe; MySQL keeps the null-safe path for non-null sorts.