### PR TITLE
Rewrite Postgres example as Compose-backed feature tour

### DIFF
--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -1,0 +1,99 @@
+# PostgreSQL example — kysely-cursor
+
+A small, runnable tour of [kysely-cursor](../..) against Postgres. It seeds a `posts` table and walks through the library’s main APIs the way you’d use them in an app.
+
+## Database lifecycle (Compose, not Testcontainers)
+
+This example uses **Docker Compose + pnpm scripts**, not Testcontainers.
+
+| Approach                            | Good for                                                                                          |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Compose + scripts** (what we use) | Learning / iterating: DB stays up, reconnect with `psql`, re-run demos in ~1s, no extra Node deps |
+| **Testcontainers**                  | Automated tests in CI (this repo’s `test/dialect/*.test.ts`) — isolated, ephemeral, parallel      |
+
+The demo code never starts Docker itself; `package.json` owns that boundary so `index.ts` stays about the library.
+
+## Prerequisites
+
+- Node.js 18+
+- Docker with Compose v2 (`docker compose`, including `up --wait`)
+- Dependencies from the monorepo root (`pnpm install`)
+
+## Run
+
+From the **repo root** (starts Compose Postgres, then demos):
+
+```bash
+pnpm example:postgres
+```
+
+From this directory:
+
+```bash
+pnpm start          # db:up + demos (preferred)
+pnpm db:up          # start Postgres only (stays up for iteration)
+pnpm dev            # demos only (expects DB already up)
+pnpm db:down        # stop / remove the container
+pnpm db:reset       # wipe volume and recreate
+```
+
+Compose uses host port **54329** (avoids clashing with a system Postgres on 5432) and database `kysely_cursor_example`.
+
+### Environment
+
+| Variable            | Default                                                              | Purpose                                                               |
+| ------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `DATABASE_URL`      | `postgres://postgres:postgres@localhost:54329/kysely_cursor_example` | Override to use your own Postgres                                     |
+| `PAGINATION_SECRET` | _(unset)_                                                            | When set, page tokens are encrypted (SuperJSON → AES-GCM → Base64URL) |
+
+```bash
+PAGINATION_SECRET='dev-only-secret' pnpm start
+```
+
+```bash
+# Bring-your-own database (skips needing Compose if you only run `pnpm dev`)
+DATABASE_URL=postgres://user:pass@localhost:5432/mydb pnpm dev
+```
+
+## What it demonstrates
+
+| #   | Demo                      | Library surface                                 |
+| --- | ------------------------- | ----------------------------------------------- |
+| 1   | Forward / back pagination | `paginate` + `cursor: { nextPage \| prevPage }` |
+| 2   | Filtered author feed      | Same sorts, different `WHERE` query             |
+| 3   | Nullable column ordering  | `nulls: 'last'` on Postgres                     |
+| 4   | Connection-style edges    | `paginateWithEdges`                             |
+| 5   | Numeric offset            | `cursor: { offset }`                            |
+| 6   | Full result walk          | Loop on `nextPage` until exhausted              |
+
+Also covered in the supporting modules:
+
+- **`nullable: false`** on non-null feed keys for simpler/faster keyset SQL on Postgres
+- **Composite indexes** that match sort shapes
+- **Pluggable codecs** — default SuperJSON → Base64URL, optional AES-GCM via `PAGINATION_SECRET`
+
+## Layout
+
+```
+examples/postgres/
+  docker-compose.yml   Example Postgres (port 54329)
+  package.json         db:up / db:down / start / dev
+  index.ts             Entry: connect → migrate → seed → demos
+  db.ts                Schema, indexes, deterministic seed
+  paginator.ts         createPaginator + codec pipelines
+  demos.ts             One function per feature
+  README.md            This file
+```
+
+Copy patterns from `paginator.ts` and `demos.ts` into your app; Compose scripts are just harness.
+
+## Key takeaways
+
+1. **Sorts must uniquely identify rows** — end with a non-null unique key (usually primary key).
+2. **Reuse one paginator** — dialect and codec are app-level; only query / sorts / cursor change per request.
+3. **Match indexes to sorts** — e.g. `(created_at DESC, id DESC)` for the feed.
+4. **Mark non-null leading keys** with `nullable: false` when you want simpler deep-page keyset SQL.
+5. **Keep the same `sorts` array** when following `nextPage` / `prevPage` (tokens include a sort signature).
+6. Prefer keyset over **offset** for deep pages; use offset only for legacy page numbers or shallow admin UIs.
+
+For full API docs, see the [root README](../../README.md).

--- a/examples/postgres/db.ts
+++ b/examples/postgres/db.ts
@@ -1,0 +1,111 @@
+import { type Generated, Kysely, PostgresDialect, sql } from 'kysely'
+import { Pool } from 'pg'
+
+/**
+ * Tiny blog schema used by the demos.
+ *
+ * Indexes match the common keyset sort shapes so Postgres can seek instead of
+ * scanning — the same composite indexes you want in production.
+ */
+export type Post = {
+  id: Generated<number>
+  title: string
+  author: string
+  /** Higher is better — used by the scoreboard demo. */
+  score: number
+  /** Null means draft / not yet published. */
+  published_at: Date | null
+  created_at: Date
+}
+
+export type Database = {
+  posts: Post
+}
+
+export type PostRow = {
+  id: number
+  title: string
+  author: string
+  score: number
+  published_at: Date | null
+  created_at: Date
+}
+
+const AUTHORS = ['ada', 'grace', 'linus', 'barbara'] as const
+
+export function createDb(connectionString: string): Kysely<Database> {
+  const pool = new Pool({ connectionString })
+  return new Kysely<Database>({
+    dialect: new PostgresDialect({ pool }),
+  })
+}
+
+export async function migrate(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .createTable('posts')
+    .ifNotExists()
+    .addColumn('id', 'serial', (col) => col.primaryKey())
+    .addColumn('title', 'text', (col) => col.notNull())
+    .addColumn('author', 'text', (col) => col.notNull())
+    .addColumn('score', 'integer', (col) => col.notNull())
+    .addColumn('published_at', 'timestamptz')
+    .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+    .execute()
+
+  // Feed: (created_at DESC, id DESC) — matches nullable:false seek path on Postgres.
+  await sql`
+    create index if not exists posts_created_at_id_desc
+    on posts (created_at desc, id desc)
+  `.execute(db)
+
+  // Author timeline: equality on author + same keyset tail.
+  await sql`
+    create index if not exists posts_author_created_at_id_desc
+    on posts (author, created_at desc, id desc)
+  `.execute(db)
+
+  // Scoreboard.
+  await sql`
+    create index if not exists posts_score_id_desc
+    on posts (score desc, id desc)
+  `.execute(db)
+
+  // Published feed with drafts (null published_at) ordered last.
+  await sql`
+    create index if not exists posts_published_at_id_desc
+    on posts (published_at desc nulls last, id desc)
+  `.execute(db)
+}
+
+/** Deterministic seed so re-runs are stable and demos print the same shape. */
+export async function seed(db: Kysely<Database>, count = 24): Promise<void> {
+  const existing = await db
+    .selectFrom('posts')
+    .select((eb) => eb.fn.countAll<string>().as('count'))
+    .executeTakeFirstOrThrow()
+
+  if (Number(existing.count) >= count) return
+
+  await db.deleteFrom('posts').execute()
+
+  const base = Date.UTC(2024, 0, 1, 12, 0, 0)
+  const rows = Array.from({ length: count }, (_, i) => {
+    const n = i + 1
+    const isDraft = n % 5 === 0
+    return {
+      title: `Post ${String(n).padStart(2, '0')}`,
+      author: AUTHORS[i % AUTHORS.length]!,
+      score: (n * 17) % 100,
+      // Every 5th post is a draft (null published_at).
+      published_at: isDraft ? null : new Date(base + i * 3_600_000),
+      created_at: new Date(base + i * 3_600_000),
+    }
+  })
+
+  await db.insertInto('posts').values(rows).execute()
+}
+
+/** Kysely owns the pool lifecycle when the dialect was given that pool. */
+export async function destroy(db: Kysely<Database>): Promise<void> {
+  await db.destroy()
+}

--- a/examples/postgres/demos.ts
+++ b/examples/postgres/demos.ts
@@ -1,0 +1,255 @@
+import type { Kysely } from 'kysely'
+import type { Paginator } from 'kysely-cursor'
+
+import type { Database, PostRow } from './db.js'
+
+const PAGE_SIZE = 5
+
+/** Chronological feed — `nullable: false` on non-null keys for simpler keyset SQL. */
+export const feedSorts = [
+  {
+    col: 'posts.created_at' as const,
+    dir: 'desc' as const,
+    output: 'created_at' as const,
+    /** Assert no NULLs so the library can use a simpler deep-page predicate. */
+    nullable: false as const,
+  },
+  // Final sort must be unique + non-nullable (tie-breaker). Prefer a primary key.
+  { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
+] as const
+
+/** Ranking by score. */
+export const scoreSorts = [
+  {
+    col: 'posts.score' as const,
+    dir: 'desc' as const,
+    output: 'score' as const,
+    nullable: false as const,
+  },
+  { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
+] as const
+
+/**
+ * Nullable `published_at` with explicit NULLS LAST (Postgres supports the directive).
+ * Do **not** set `nullable: false` here — drafts are NULL and need the null-safe path.
+ */
+export const publishedSorts = [
+  {
+    col: 'posts.published_at' as const,
+    dir: 'desc' as const,
+    output: 'published_at' as const,
+    nulls: 'last' as const,
+  },
+  { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
+] as const
+
+function postsQuery(db: Kysely<Database>) {
+  return db.selectFrom('posts').select(['id', 'title', 'author', 'score', 'published_at', 'created_at'])
+}
+
+function fmtDate(d: Date | null): string {
+  if (!d) return '—'
+  return d.toISOString().replace('T', ' ').slice(0, 19)
+}
+
+function printRows(rows: PostRow[], extra?: (r: PostRow) => Record<string, unknown>) {
+  console.table(
+    rows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      author: r.author,
+      score: r.score,
+      published_at: fmtDate(r.published_at),
+      created_at: fmtDate(r.created_at),
+      ...extra?.(r),
+    })),
+  )
+}
+
+function printPageMeta(page: {
+  hasPrevPage: boolean
+  hasNextPage: boolean
+  prevPage?: string
+  nextPage?: string
+  startCursor?: string
+  endCursor?: string
+}) {
+  const clip = (t?: string) => (t ? `${t.slice(0, 28)}…` : undefined)
+  console.log('  hasPrevPage:', page.hasPrevPage, ' hasNextPage:', page.hasNextPage)
+  console.log('  prevPage:   ', clip(page.prevPage))
+  console.log('  nextPage:   ', clip(page.nextPage))
+  console.log('  startCursor:', clip(page.startCursor))
+  console.log('  endCursor:  ', clip(page.endCursor))
+}
+
+function heading(title: string, blurb: string) {
+  console.log('\n' + '─'.repeat(72))
+  console.log(` ${title}`)
+  console.log('─'.repeat(72))
+  console.log(` ${blurb}\n`)
+}
+
+/** Demo 1 — first page, next page, then walk back with prevPage. */
+export async function demoForwardAndBack(db: Kysely<Database>, paginator: Paginator) {
+  heading(
+    '1. Forward / back keyset pagination',
+    'Tokens are opaque; sorts must stay identical between requests (signature check).',
+  )
+
+  const query = postsQuery(db)
+
+  const page1 = await paginator.paginate({
+    query,
+    sorts: feedSorts,
+    limit: PAGE_SIZE,
+  })
+
+  console.log('Page 1 (newest first):')
+  printRows(page1.items)
+  printPageMeta(page1)
+
+  if (!page1.nextPage) {
+    console.log('No next page — seed more rows if you expected one.')
+    return
+  }
+
+  const page2 = await paginator.paginate({
+    query,
+    sorts: feedSorts,
+    limit: PAGE_SIZE,
+    cursor: { nextPage: page1.nextPage },
+  })
+
+  console.log('\nPage 2 (forward via nextPage):')
+  printRows(page2.items)
+  printPageMeta(page2)
+
+  if (!page2.prevPage) return
+
+  const back = await paginator.paginate({
+    query,
+    sorts: feedSorts,
+    limit: PAGE_SIZE,
+    cursor: { prevPage: page2.prevPage },
+  })
+
+  console.log('\nBack to page 1 (via prevPage — library inverts sorts internally):')
+  printRows(back.items)
+  printPageMeta(back)
+
+  const sameIds = page1.items.length === back.items.length && page1.items.every((r, i) => r.id === back.items[i]?.id)
+  console.log(sameIds ? '\n✓ Backward page matches page 1 item ids.' : '\n✗ Unexpected mismatch walking back.')
+}
+
+/** Demo 2 — same paginator + sorts, different filtered query (author timeline). */
+export async function demoFilteredFeed(db: Kysely<Database>, paginator: Paginator) {
+  heading(
+    '2. Filtered feed (author timeline)',
+    'Keyset works with WHERE filters — keep an index that starts with the filter columns.',
+  )
+
+  const author = 'ada'
+  const query = postsQuery(db).where('author', '=', author)
+
+  const page = await paginator.paginate({
+    query,
+    sorts: feedSorts,
+    limit: PAGE_SIZE,
+  })
+
+  console.log(`First page for author="${author}":`)
+  printRows(page.items)
+  printPageMeta(page)
+}
+
+/** Demo 3 — nullable sort key + explicit nulls: 'last' (Postgres NULLS LAST). */
+export async function demoNullablePublishedAt(db: Kysely<Database>, paginator: Paginator) {
+  heading(
+    "3. Nullable sort + nulls: 'last'",
+    'Drafts (published_at IS NULL) sort after published posts. Uses null-safe keyset SQL.',
+  )
+
+  const page = await paginator.paginate({
+    query: postsQuery(db),
+    sorts: publishedSorts,
+    limit: PAGE_SIZE,
+  })
+
+  console.log('First page (published first; drafts last overall):')
+  printRows(page.items)
+  printPageMeta(page)
+}
+
+/** Demo 4 — GraphQL-style edges with a per-item cursor. */
+export async function demoWithEdges(db: Kysely<Database>, paginator: Paginator) {
+  heading('4. paginateWithEdges', 'Same as paginate, plus edges[] of { node, cursor } for connection-style APIs.')
+
+  const result = await paginator.paginateWithEdges({
+    query: postsQuery(db),
+    sorts: scoreSorts,
+    limit: 3,
+  })
+
+  console.log('Scoreboard (top scores) as edges:')
+  console.table(
+    result.edges.map((e, i) => ({
+      i,
+      cursor: `${e.cursor.slice(0, 24)}…`,
+      id: e.node.id,
+      title: e.node.title,
+      score: e.node.score,
+    })),
+  )
+  printPageMeta(result)
+}
+
+/** Demo 5 — numeric offset when you must (legacy UI page numbers). Prefer keyset. */
+export async function demoOffsetFallback(db: Kysely<Database>, paginator: Paginator) {
+  heading('5. Offset fallback', 'cursor: { offset } skips N rows. Fine for small N / admin tools; avoid deep pages.')
+
+  const page = await paginator.paginate({
+    query: postsQuery(db),
+    sorts: feedSorts,
+    limit: PAGE_SIZE,
+    // Skip first page (5 rows) → roughly “page 2” of a 1-based UI.
+    cursor: { offset: PAGE_SIZE },
+  })
+
+  console.log(`After offset=${PAGE_SIZE}:`)
+  printRows(page.items)
+  printPageMeta(page)
+}
+
+/**
+ * Demo 6 — walk the whole feed with nextPage until exhausted.
+ * Useful pattern for exports / background jobs.
+ */
+export async function demoWalkAll(db: Kysely<Database>, paginator: Paginator) {
+  heading(
+    '6. Walk entire result set',
+    'Loop on nextPage until hasNextPage is false — stable under concurrent inserts at the head.',
+  )
+
+  const query = postsQuery(db)
+  let cursor: { nextPage: string } | undefined
+  let pageNo = 0
+  let total = 0
+
+  for (;;) {
+    const page = await paginator.paginate({
+      query,
+      sorts: feedSorts,
+      limit: PAGE_SIZE,
+      cursor,
+    })
+    pageNo += 1
+    total += page.items.length
+    const ids = page.items.map((r) => r.id).join(', ')
+    console.log(`  page ${pageNo}: ${page.items.length} rows  ids=[${ids}]`)
+
+    if (!page.hasNextPage || !page.nextPage) break
+    cursor = { nextPage: page.nextPage }
+  }
+
+  console.log(`\nWalked ${total} rows across ${pageNo} page(s).`)
+}

--- a/examples/postgres/docker-compose.yml
+++ b/examples/postgres/docker-compose.yml
@@ -1,0 +1,20 @@
+# Local Postgres for the kysely-cursor example.
+# Managed via package.json: pnpm db:up | db:down | start
+name: kysely-cursor-example-postgres
+
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: kysely_cursor_example
+    ports:
+      # Dedicated host port so we don't fight a system Postgres on 5432.
+      - '54329:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d kysely_cursor_example']
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      start_period: 5s

--- a/examples/postgres/index.ts
+++ b/examples/postgres/index.ts
@@ -1,105 +1,88 @@
-import { Generated, Kysely, PostgresDialect, sql } from 'kysely'
-import { Pool } from 'pg'
-import { createPaginator, PostgresPaginationDialect } from 'kysely-cursor'
+/**
+ * kysely-cursor — PostgreSQL example
+ *
+ * Walks through the main library features against a small `posts` table:
+ *   1. Forward / back keyset pagination
+ *   2. Filtered feeds (same sorts, different query)
+ *   3. Nullable sorts with `nulls: 'last'`
+ *   4. `paginateWithEdges` (connection-style)
+ *   5. Offset fallback
+ *   6. Walking an entire result set
+ *
+ * Database lifecycle is owned by package scripts (Docker Compose), not this file:
+ *   pnpm start     # db:up + run demos (preferred)
+ *   pnpm db:up     # start Postgres only
+ *   pnpm db:down   # stop Postgres
+ *   pnpm dev       # demos only (DB must already be up, or set DATABASE_URL)
+ *
+ * From repo root: pnpm example:postgres
+ */
 
-type User = {
-  id: Generated<number>
-  name: string
-  created_at: Date
-}
+import { createDb, destroy, migrate, seed } from './db.js'
+import {
+  demoFilteredFeed,
+  demoForwardAndBack,
+  demoNullablePublishedAt,
+  demoOffsetFallback,
+  demoWalkAll,
+  demoWithEdges,
+} from './demos.js'
+import { createAppPaginator } from './paginator.js'
 
-type DB = {
-  users: User
-}
+/** Matches docker-compose.yml (host port 54329 → container 5432). */
+export const DEFAULT_DATABASE_URL = 'postgres://postgres:postgres@localhost:54329/kysely_cursor_example'
 
 async function main() {
-  const connectionString = process.env.DATABASE_URL ?? 'postgres://postgres:postgres@localhost:5432/postgres'
+  const connectionString = process.env.DATABASE_URL ?? DEFAULT_DATABASE_URL
 
-  const db = new Kysely<DB>({
-    dialect: new PostgresDialect({
-      pool: new Pool({ connectionString }),
-    }),
-  })
+  console.log('kysely-cursor · PostgreSQL example')
+  console.log(`connecting: ${connectionString.replace(/:[^:@/]+@/, ':***@')}`)
+
+  const db = createDb(connectionString)
 
   try {
-    await db.schema
-      .createTable('users')
-      .ifNotExists()
-      .addColumn('id', 'serial', (col) => col.primaryKey())
-      .addColumn('name', 'text')
-      .addColumn('created_at', 'timestamp', (col) =>
-        col.notNull().defaultTo(sql`now
-      ()`),
-      )
-      .execute()
+    await migrate(db)
+    await seed(db)
 
-    const countRow = await db
-      .selectFrom('users')
-      .select(sql`count(0)::int`.as('count'))
-      .executeTakeFirst()
-    const rowCount = (countRow?.count ?? 0) as number
-
-    if (rowCount < 10) {
-      const now = Date.now()
-      const rows = Array.from({ length: 12 }, (_, i) => ({
-        name: `User ${String(i + 1).padStart(2, '0')}`,
-        created_at: new Date(now - i * 60 * 60 * 1000), // 1h apart
-      }))
-      await db.insertInto('users').values(rows).execute()
-    }
-
-    const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
-
-    const sorts = [
-      { col: 'created_at', dir: 'desc' },
-      { col: 'id', dir: 'desc' }, // final non-nullable sort for deterministic ordering
-    ] as const
-    const limit = 5
-
-    const query = db.selectFrom('users').select(['id', 'name', 'created_at'])
-
-    // Page 1
-    const page1 = await paginator.paginate({
-      query,
-      sorts,
-      limit,
+    // Optional: set PAGINATION_SECRET to encrypt page tokens (AES-GCM).
+    const paginator = createAppPaginator({
+      secret: process.env.PAGINATION_SECRET,
     })
-    console.log('\nPage 1:')
-    console.table(page1.items.map((r) => ({ id: r.id, name: r.name, created_at: r.created_at })))
-    console.log('nextPage:', page1.nextPage ? `${page1.nextPage.slice(0, 24)}…` : undefined)
 
-    // Page 2 (forward)
-    if (page1.nextPage) {
-      const page2 = await paginator.paginate({
-        query,
-        sorts,
-        limit,
-        cursor: { nextPage: page1.nextPage },
-      })
-      console.log('\nPage 2 (forward):')
-      console.table(page2.items.map((r) => ({ id: r.id, name: r.name, created_at: r.created_at })))
-      console.log('prevPage:', page2.prevPage ? `${page2.prevPage.slice(0, 24)}…` : undefined)
-
-      // Back to Page 1 (backward)
-      if (page2.prevPage) {
-        const backTo1 = await paginator.paginate({
-          query,
-          sorts,
-          limit,
-          cursor: { prevPage: page2.prevPage },
-        })
-        console.log('\nBack to Page 1 (backward):')
-        console.table(backTo1.items.map((r) => ({ id: r.id, name: r.name, created_at: r.created_at })))
-      }
+    if (process.env.PAGINATION_SECRET) {
+      console.log('cursor codec: SuperJSON → AES-GCM → Base64URL (PAGINATION_SECRET set)')
+    } else {
+      console.log('cursor codec: SuperJSON → Base64URL (library default)')
+      console.log('tip: export PAGINATION_SECRET=… to demo encrypted tokens')
     }
+
+    await demoForwardAndBack(db, paginator)
+    await demoFilteredFeed(db, paginator)
+    await demoNullablePublishedAt(db, paginator)
+    await demoWithEdges(db, paginator)
+    await demoOffsetFallback(db, paginator)
+    await demoWalkAll(db, paginator)
+
+    console.log('\n' + '─'.repeat(72))
+    console.log(' Done. See README.md in this folder for what each demo shows.')
+    console.log('─'.repeat(72) + '\n')
   } finally {
-    await db.destroy()
+    await destroy(db)
   }
 }
 
 try {
   await main()
 } catch (err) {
-  console.error(err)
+  console.error('\nExample failed:', err)
+  console.error(`
+Is the example Postgres up?
+
+  pnpm start      # from examples/postgres — starts Compose DB + runs demos
+  pnpm db:up      # start DB only, then pnpm dev
+  pnpm db:down    # stop when finished
+
+Or set DATABASE_URL to any reachable Postgres instance.
+`)
   process.exitCode = 1
 }

--- a/examples/postgres/package.json
+++ b/examples/postgres/package.json
@@ -3,14 +3,21 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx index.ts"
+    "db:up": "docker compose up -d --wait",
+    "db:down": "docker compose down",
+    "db:reset": "docker compose down -v && docker compose up -d --wait",
+    "dev": "tsx index.ts",
+    "start": "pnpm db:up && pnpm dev",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "kysely": "^0.28.8",
     "kysely-cursor": "workspace:*",
-    "kysely": "^0.28.7",
     "pg": "^8.11.5"
   },
   "devDependencies": {
+    "@types/node": "^24.7.1",
+    "@types/pg": "^8.15.5",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3"
   }

--- a/examples/postgres/paginator.ts
+++ b/examples/postgres/paginator.ts
@@ -1,0 +1,39 @@
+import {
+  base64UrlCodec,
+  codecPipe,
+  createAesCodec,
+  createPaginator,
+  PostgresPaginationDialect,
+  superJsonCodec,
+  type Paginator,
+} from 'kysely-cursor'
+
+/**
+ * Default opaque tokens: SuperJSON (Dates, BigInts, …) → Base64 URL-safe string.
+ * This is also the library default when you omit `cursorCodec`.
+ */
+export const defaultCursorCodec = codecPipe(superJsonCodec, base64UrlCodec)
+
+/**
+ * Production-style tokens: SuperJSON → AES-GCM → Base64 URL.
+ * Set `PAGINATION_SECRET` to try the encrypted demo path.
+ */
+export function createEncryptedCursorCodec(secret: string) {
+  return codecPipe(superJsonCodec, createAesCodec(secret), base64UrlCodec)
+}
+
+/**
+ * One paginator per app (or per token policy). Reuse it for every page request —
+ * dialect + codec stay fixed; only the query / sorts / cursor change.
+ */
+export function createAppPaginator(options?: {
+  /** Prefer encrypted tokens when a secret is available. */
+  secret?: string
+}): Paginator {
+  const cursorCodec = options?.secret ? createEncryptedCursorCodec(options.secret) : defaultCursorCodec
+
+  return createPaginator({
+    dialect: new PostgresPaginationDialect(),
+    cursorCodec,
+  })
+}

--- a/examples/postgres/tsconfig.json
+++ b/examples/postgres/tsconfig.json
@@ -1,11 +1,18 @@
 {
   "compilerOptions": {
     "module": "nodenext",
+    "moduleResolution": "nodenext",
     "target": "es2022",
-    "noUncheckedIndexedAccess": true,
+    "lib": ["es2022"],
+    "types": ["node"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
-    "skipLibCheck": true
-  }
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:publish": "changeset publish",
-    "example:postgres": "pnpm --filter kysely-cursor-example-postgres dev",
+    "example:postgres": "pnpm --filter kysely-cursor-example-postgres start",
     "bench": "pnpm --filter kysely-cursor-bench bench",
     "bench:quick": "pnpm --filter kysely-cursor-bench bench:quick",
     "bench:ci": "pnpm --filter kysely-cursor-bench bench:ci",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
   examples/postgres:
     dependencies:
       kysely:
-        specifier: ^0.28.7
+        specifier: ^0.28.8
         version: 0.28.8
       kysely-cursor:
         specifier: workspace:*
@@ -161,6 +161,12 @@ importers:
         specifier: ^8.11.5
         version: 8.16.3
     devDependencies:
+      '@types/node':
+        specifier: ^24.7.1
+        version: 24.8.1
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
       tsx:
         specifier: ^4.19.2
         version: 4.20.6
@@ -4222,13 +4228,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 24.8.1
+      '@types/node': 26.1.1
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@3.3.44':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 24.8.1
+      '@types/node': 26.1.1
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
@@ -4264,20 +4270,20 @@ snapshots:
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 26.1.1
-      pg-protocol: 1.10.3
+      pg-protocol: 1.15.0
       pg-types: 2.2.0
 
   '@types/readable-stream@4.0.21':
     dependencies:
-      '@types/node': 24.8.1
+      '@types/node': 26.1.1
 
   '@types/ssh2-streams@0.1.12':
     dependencies:
-      '@types/node': 24.8.1
+      '@types/node': 26.1.1
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 24.8.1
+      '@types/node': 26.1.1
       '@types/ssh2-streams': 0.1.12
 
   '@types/ssh2@1.15.5':
@@ -6093,7 +6099,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.8.1
+      '@types/node': 26.1.1
       long: 5.3.2
 
   pump@3.0.3:


### PR DESCRIPTION
Reworks the Postgres example into a Docker Compose–backed tour of the library (nulls, edges, offset, and nullable: false feed sorts) with clear run scripts from the repo root.