### PR TITLE
Fix bench-report baseline update missing library build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Merge CLI only needs baseline JSON, but entrypoint modules historically
+      # pulled dialects → kysely-cursor/dist. Build keeps the job robust even if
+      # imports change; --merge itself no longer requires dist.
+      - name: Build library
+        run: pnpm run build
+
       - name: Download dialect artifacts
         uses: actions/download-artifact@v4
         with:

--- a/bench/src/index.ts
+++ b/bench/src/index.ts
@@ -6,7 +6,6 @@ import { DEFAULT_BASELINE_DIR, DEFAULT_BASELINE_JSON, loadBaseline, mergeBaselin
 import { compareBaselines, DEFAULT_REGRESSION_THRESHOLD, hasRegressions, renderCompareMarkdown } from './compare.js'
 import { describeConfig, parseArgs } from './config.js'
 import { renderBaselineMarkdown, renderConsole, writeReports } from './report.js'
-import { runBenchmarks } from './runner.js'
 import type { BaselineReport, BenchReport } from './types.js'
 
 const printHelp = () => {
@@ -161,6 +160,10 @@ const main = async () => {
     await maybeWriteBaseline(current)
     return
   }
+
+  // Lazy-load runner (and thus dialect drivers / kysely-cursor) only for live runs.
+  // --merge / --current must work without a built library dist (CI bench-report job).
+  const { runBenchmarks } = await import('./runner.js')
 
   const cfg = parseArgs(argv)
   console.log('kysely-cursor benchmarks')


### PR DESCRIPTION
The main baseline commit failed because `bench-report` never built `kysely-cursor`, while the merge CLI still imported dialect modules that require `dist/`. Lazy-load the runner for `--merge`/`--current` and build the library in that job.