### PR TITLE
Tighten CI bench gate against runner noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ on:
 permissions:
   contents: read
 
+# One active CI run per PR / branch; new pushes cancel the previous run instead of queuing.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/bench/README.md
+++ b/bench/README.md
@@ -222,6 +222,11 @@ A **regression** is any matched cell whose **cursor mean** is ≥ `threshold`× 
 baseline (default **1.5**). The primary signal is library keyset latency, not
 offset (engine behavior we do not control).
 
+**CI gating** (`--fail-on-regression`) only fails the job for library scenarios at
+**depth ≥ 100** or sequential **walk** cells. Shallow depths and `ideal-baseline`
+(raw SQL ceiling) still appear in the report as informational — runner noise often
+dominates sub-ms cells.
+
 | Flag                   | Meaning                                                          |
 | ---------------------- | ---------------------------------------------------------------- |
 | `--compare`            | Diff current run (or `--current` / `--merge`) against baseline   |
@@ -229,7 +234,7 @@ offset (engine behavior we do not control).
 | `--merge <path[,…]>`   | Merge partial baseline JSON files or dirs (CI matrix); skips run |
 | `--baseline <path>`    | Baseline JSON (default `bench/baseline/results.json`)            |
 | `--threshold <n>`      | Cursor-mean ratio that counts as a regression                    |
-| `--fail-on-regression` | Exit 1 when any cell is a regression                             |
+| `--fail-on-regression` | Exit 1 on CI-gating regressions (see above)                      |
 | `--comment-out <path>` | Write the compare markdown (for PR comments)                     |
 | `--update-baseline`    | Write `bench/baseline/{results.json,summary.md}`                 |
 | `--git-sha <sha>`      | Embed SHA in the JSON (CI sets this from `GITHUB_SHA`)           |
@@ -246,8 +251,9 @@ Benchmarks run as a **dialect matrix** in `.github/workflows/ci.yml`
 1. Each **Bench (dialect)** job builds the library, runs that dialect only
    (same seed/page/depth config as the committed baseline), and diffs its cells
    against `bench/baseline/results.json` (compare scopes to dialects present in
-   the current run). The job fails on cursor-mean regressions ≥ 1.5× when the
-   baseline was produced on CI (`gitSha` set).
+   the current run). The job fails on **CI-gating** cursor-mean regressions ≥ 1.5×
+   (library path, depth ≥ 100 or walks) when the baseline was produced on CI
+   (`gitSha` set).
 2. **Bench report** downloads all dialect artifacts, merges them with
    `--merge bench/artifacts`, and:
    - On **pull_request**: posts a sticky PR comment with the combined compare report.

--- a/bench/baseline/results.json
+++ b/bench/baseline/results.json
@@ -5,23 +5,11 @@
   "config": {
     "rowCount": 50000,
     "pageSize": 25,
-    "deepPageDepths": [
-      0,
-      10,
-      50,
-      100,
-      500,
-      1000
-    ],
+    "deepPageDepths": [0, 10, 50, 100, 500, 1000],
     "walkPages": 40,
     "iterations": 6,
     "warmup": 2,
-    "dialects": [
-      "postgres",
-      "mysql",
-      "mssql",
-      "sqlite"
-    ]
+    "dialects": ["postgres", "mysql", "mssql", "sqlite"]
   },
   "cells": [
     {

--- a/bench/baseline/summary.md
+++ b/bench/baseline/summary.md
@@ -6,256 +6,256 @@ Cursor = keyset via library API (`nullable: false` on non-null keys). Offset = b
 
 ## Headline — deepest deep-page
 
-| Dialect | Label | Cursor | Offset | Speedup |
-| --- | --- | ---: | ---: | ---: |
-| postgres | depth=1000 | 1.04ms | 2.86ms | 2.74× |
-| mysql | depth=1000 | 0.629ms | 81.1ms | 129× |
-| mssql | depth=1000 | 12.9ms | 46.2ms | 3.58× |
-| sqlite | depth=1000 | 0.198ms | 0.753ms | 3.81× |
+| Dialect  | Label      |  Cursor |  Offset | Speedup |
+| -------- | ---------- | ------: | ------: | ------: |
+| postgres | depth=1000 |  1.04ms |  2.86ms |   2.74× |
+| mysql    | depth=1000 | 0.629ms |  81.1ms |    129× |
+| mssql    | depth=1000 |  12.9ms |  46.2ms |   3.58× |
+| sqlite   | depth=1000 | 0.198ms | 0.753ms |   3.81× |
 
 ## postgres
 
 ### deep-page
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.990ms | 1.00ms | 1.01× | 0.012ms |
-| depth=10 | 0.923ms | 0.786ms | 0.85× | -0.137ms |
-| depth=50 | 0.832ms | 0.979ms | 1.18× | 0.146ms |
-| depth=100 | 0.975ms | 1.19ms | 1.22× | 0.215ms |
-| depth=500 | 0.745ms | 1.74ms | 2.34× | 0.995ms |
-| depth=1000 | 1.04ms | 2.86ms | 2.74× | 1.82ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.990ms |  1.00ms |   1.01× |  0.012ms |
+| depth=10   | 0.923ms | 0.786ms |   0.85× | -0.137ms |
+| depth=50   | 0.832ms | 0.979ms |   1.18× |  0.146ms |
+| depth=100  | 0.975ms |  1.19ms |   1.22× |  0.215ms |
+| depth=500  | 0.745ms |  1.74ms |   2.34× |  0.995ms |
+| depth=1000 |  1.04ms |  2.86ms |   2.74× |   1.82ms |
 
 ### sequential-walk
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| walk=40 | 28.8ms | 25.2ms | 0.87× | -3.619ms |
+| Label   | Cursor | Offset | Speedup |     Δ ms |
+| ------- | -----: | -----: | ------: | -------: |
+| walk=40 | 28.8ms | 25.2ms |   0.87× | -3.619ms |
 
 ### filtered-feed
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 1.17ms | 0.637ms | 0.54× | -0.532ms |
-| depth=10 | 1.08ms | 0.877ms | 0.81× | -0.203ms |
-| depth=50 | 0.712ms | 1.26ms | 1.77× | 0.545ms |
-| depth=100 | 0.652ms | 1.06ms | 1.63× | 0.411ms |
-| depth=500 | 0.623ms | 4.96ms | 7.96× | 4.34ms |
-| depth=1000 | 0.582ms | 10.5ms | 18.0× | 9.92ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    |  1.17ms | 0.637ms |   0.54× | -0.532ms |
+| depth=10   |  1.08ms | 0.877ms |   0.81× | -0.203ms |
+| depth=50   | 0.712ms |  1.26ms |   1.77× |  0.545ms |
+| depth=100  | 0.652ms |  1.06ms |   1.63× |  0.411ms |
+| depth=500  | 0.623ms |  4.96ms |   7.96× |   4.34ms |
+| depth=1000 | 0.582ms |  10.5ms |   18.0× |   9.92ms |
 
 ### author-timeline
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.505ms | 0.501ms | 0.99× | -0.004ms |
-| depth=5 | 0.591ms | 0.547ms | 0.92× | -0.044ms |
-| depth=10 | 0.587ms | 0.567ms | 0.97× | -0.020ms |
-| depth=25 | 0.563ms | 0.729ms | 1.30× | 0.167ms |
-| walk=40 | 25.7ms | 32.3ms | 1.26× | 6.66ms |
+| Label    |  Cursor |  Offset | Speedup |     Δ ms |
+| -------- | ------: | ------: | ------: | -------: |
+| depth=0  | 0.505ms | 0.501ms |   0.99× | -0.004ms |
+| depth=5  | 0.591ms | 0.547ms |   0.92× | -0.044ms |
+| depth=10 | 0.587ms | 0.567ms |   0.97× | -0.020ms |
+| depth=25 | 0.563ms | 0.729ms |   1.30× |  0.167ms |
+| walk=40  |  25.7ms |  32.3ms |   1.26× |   6.66ms |
 
 ### scoreboard
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.492ms | 0.862ms | 1.75× | 0.370ms |
-| depth=10 | 0.584ms | 0.545ms | 0.93× | -0.039ms |
-| depth=50 | 0.613ms | 0.873ms | 1.42× | 0.260ms |
-| depth=100 | 0.545ms | 0.932ms | 1.71× | 0.387ms |
-| depth=500 | 0.545ms | 2.77ms | 5.07× | 2.22ms |
-| depth=1000 | 0.664ms | 5.23ms | 7.87× | 4.56ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.492ms | 0.862ms |   1.75× |  0.370ms |
+| depth=10   | 0.584ms | 0.545ms |   0.93× | -0.039ms |
+| depth=50   | 0.613ms | 0.873ms |   1.42× |  0.260ms |
+| depth=100  | 0.545ms | 0.932ms |   1.71× |  0.387ms |
+| depth=500  | 0.545ms |  2.77ms |   5.07× |   2.22ms |
+| depth=1000 | 0.664ms |  5.23ms |   7.87× |   4.56ms |
 
 ### ideal-baseline
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.442ms | 0.745ms | 1.69× | 0.303ms |
-| depth=50 | 0.486ms | 0.576ms | 1.19× | 0.090ms |
-| depth=100 | 0.472ms | 0.635ms | 1.34× | 0.162ms |
-| depth=500 | 0.492ms | 1.56ms | 3.17× | 1.06ms |
-| depth=1000 | 0.467ms | 2.69ms | 5.77× | 2.23ms |
+| Label      |  Cursor |  Offset | Speedup |    Δ ms |
+| ---------- | ------: | ------: | ------: | ------: |
+| depth=0    | 0.442ms | 0.745ms |   1.69× | 0.303ms |
+| depth=50   | 0.486ms | 0.576ms |   1.19× | 0.090ms |
+| depth=100  | 0.472ms | 0.635ms |   1.34× | 0.162ms |
+| depth=500  | 0.492ms |  1.56ms |   3.17× |  1.06ms |
+| depth=1000 | 0.467ms |  2.69ms |   5.77× |  2.23ms |
 
 ## mysql
 
 ### deep-page
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.932ms | 0.780ms | 0.84× | -0.152ms |
-| depth=10 | 0.997ms | 1.03ms | 1.03× | 0.028ms |
-| depth=50 | 0.841ms | 1.92ms | 2.28× | 1.08ms |
-| depth=100 | 0.959ms | 54.3ms | 56.6× | 53.4ms |
-| depth=500 | 0.707ms | 68.5ms | 96.9× | 67.8ms |
-| depth=1000 | 0.629ms | 81.1ms | 129× | 80.5ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.932ms | 0.780ms |   0.84× | -0.152ms |
+| depth=10   | 0.997ms |  1.03ms |   1.03× |  0.028ms |
+| depth=50   | 0.841ms |  1.92ms |   2.28× |   1.08ms |
+| depth=100  | 0.959ms |  54.3ms |   56.6× |   53.4ms |
+| depth=500  | 0.707ms |  68.5ms |   96.9× |   67.8ms |
+| depth=1000 | 0.629ms |  81.1ms |    129× |   80.5ms |
 
 ### sequential-walk
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| walk=40 | 25.2ms | 39.4ms | 1.56× | 14.2ms |
+| Label   | Cursor | Offset | Speedup |   Δ ms |
+| ------- | -----: | -----: | ------: | -----: |
+| walk=40 | 25.2ms | 39.4ms |   1.56× | 14.2ms |
 
 ### filtered-feed
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.532ms | 0.557ms | 1.05× | 0.024ms |
-| depth=10 | 0.659ms | 0.826ms | 1.25× | 0.167ms |
-| depth=50 | 0.667ms | 1.90ms | 2.85× | 1.23ms |
-| depth=100 | 0.662ms | 3.20ms | 4.84× | 2.54ms |
-| depth=500 | 0.651ms | 14.5ms | 22.3× | 13.9ms |
-| depth=1000 | 0.607ms | 31.0ms | 51.0× | 30.4ms |
+| Label      |  Cursor |  Offset | Speedup |    Δ ms |
+| ---------- | ------: | ------: | ------: | ------: |
+| depth=0    | 0.532ms | 0.557ms |   1.05× | 0.024ms |
+| depth=10   | 0.659ms | 0.826ms |   1.25× | 0.167ms |
+| depth=50   | 0.667ms |  1.90ms |   2.85× |  1.23ms |
+| depth=100  | 0.662ms |  3.20ms |   4.84× |  2.54ms |
+| depth=500  | 0.651ms |  14.5ms |   22.3× |  13.9ms |
+| depth=1000 | 0.607ms |  31.0ms |   51.0× |  30.4ms |
 
 ### author-timeline
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.497ms | 0.483ms | 0.97× | -0.013ms |
-| depth=5 | 0.599ms | 1.37ms | 2.29× | 0.775ms |
-| depth=10 | 0.602ms | 0.768ms | 1.28× | 0.166ms |
-| depth=25 | 0.643ms | 1.21ms | 1.87× | 0.562ms |
-| walk=40 | 24.1ms | 41.5ms | 1.72× | 17.4ms |
+| Label    |  Cursor |  Offset | Speedup |     Δ ms |
+| -------- | ------: | ------: | ------: | -------: |
+| depth=0  | 0.497ms | 0.483ms |   0.97× | -0.013ms |
+| depth=5  | 0.599ms |  1.37ms |   2.29× |  0.775ms |
+| depth=10 | 0.602ms | 0.768ms |   1.28× |  0.166ms |
+| depth=25 | 0.643ms |  1.21ms |   1.87× |  0.562ms |
+| walk=40  |  24.1ms |  41.5ms |   1.72× |   17.4ms |
 
 ### scoreboard
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.465ms | 0.458ms | 0.99× | -0.006ms |
-| depth=10 | 0.578ms | 0.746ms | 1.29× | 0.169ms |
-| depth=50 | 0.592ms | 1.89ms | 3.19× | 1.29ms |
-| depth=100 | 0.570ms | 55.2ms | 96.7× | 54.6ms |
-| depth=500 | 0.585ms | 70.6ms | 121× | 70.0ms |
-| depth=1000 | 0.550ms | 84.3ms | 153× | 83.7ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.465ms | 0.458ms |   0.99× | -0.006ms |
+| depth=10   | 0.578ms | 0.746ms |   1.29× |  0.169ms |
+| depth=50   | 0.592ms |  1.89ms |   3.19× |   1.29ms |
+| depth=100  | 0.570ms |  55.2ms |   96.7× |   54.6ms |
+| depth=500  | 0.585ms |  70.6ms |    121× |   70.0ms |
+| depth=1000 | 0.550ms |  84.3ms |    153× |   83.7ms |
 
 ### ideal-baseline
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.399ms | 0.393ms | 0.98× | -0.006ms |
-| depth=50 | 0.510ms | 1.66ms | 3.25× | 1.15ms |
-| depth=100 | 0.484ms | 53.9ms | 111× | 53.4ms |
-| depth=500 | 0.525ms | 68.0ms | 129× | 67.5ms |
-| depth=1000 | 0.517ms | 80.9ms | 157× | 80.3ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.399ms | 0.393ms |   0.98× | -0.006ms |
+| depth=50   | 0.510ms |  1.66ms |   3.25× |   1.15ms |
+| depth=100  | 0.484ms |  53.9ms |    111× |   53.4ms |
+| depth=500  | 0.525ms |  68.0ms |    129× |   67.5ms |
+| depth=1000 | 0.517ms |  80.9ms |    157× |   80.3ms |
 
 ## mssql
 
 ### deep-page
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 2.22ms | 2.16ms | 0.97× | -0.058ms |
-| depth=10 | 2.40ms | 2.50ms | 1.04× | 0.094ms |
-| depth=50 | 2.39ms | 4.83ms | 2.02× | 2.44ms |
-| depth=100 | 2.77ms | 7.18ms | 2.59× | 4.41ms |
-| depth=500 | 8.25ms | 28.3ms | 3.44× | 20.1ms |
-| depth=1000 | 12.9ms | 46.2ms | 3.58× | 33.3ms |
+| Label      | Cursor | Offset | Speedup |     Δ ms |
+| ---------- | -----: | -----: | ------: | -------: |
+| depth=0    | 2.22ms | 2.16ms |   0.97× | -0.058ms |
+| depth=10   | 2.40ms | 2.50ms |   1.04× |  0.094ms |
+| depth=50   | 2.39ms | 4.83ms |   2.02× |   2.44ms |
+| depth=100  | 2.77ms | 7.18ms |   2.59× |   4.41ms |
+| depth=500  | 8.25ms | 28.3ms |   3.44× |   20.1ms |
+| depth=1000 | 12.9ms | 46.2ms |   3.58× |   33.3ms |
 
 ### sequential-walk
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| walk=40 | 73.6ms | 101ms | 1.38× | 27.6ms |
+| Label   | Cursor | Offset | Speedup |   Δ ms |
+| ------- | -----: | -----: | ------: | -----: |
+| walk=40 | 73.6ms |  101ms |   1.38× | 27.6ms |
 
 ### filtered-feed
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 1.41ms | 1.42ms | 1.01× | 0.014ms |
-| depth=10 | 1.62ms | 2.30ms | 1.42× | 0.675ms |
-| depth=50 | 2.09ms | 4.51ms | 2.16× | 2.42ms |
-| depth=100 | 2.66ms | 7.63ms | 2.87× | 4.97ms |
-| depth=500 | 7.23ms | 28.2ms | 3.90× | 20.9ms |
-| depth=1000 | 14.0ms | 49.3ms | 3.53× | 35.3ms |
+| Label      | Cursor | Offset | Speedup |    Δ ms |
+| ---------- | -----: | -----: | ------: | ------: |
+| depth=0    | 1.41ms | 1.42ms |   1.01× | 0.014ms |
+| depth=10   | 1.62ms | 2.30ms |   1.42× | 0.675ms |
+| depth=50   | 2.09ms | 4.51ms |   2.16× |  2.42ms |
+| depth=100  | 2.66ms | 7.63ms |   2.87× |  4.97ms |
+| depth=500  | 7.23ms | 28.2ms |   3.90× |  20.9ms |
+| depth=1000 | 14.0ms | 49.3ms |   3.53× |  35.3ms |
 
 ### author-timeline
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 1.49ms | 1.49ms | 1.00× | -0.005ms |
-| depth=5 | 1.53ms | 1.78ms | 1.17× | 0.255ms |
-| depth=10 | 1.82ms | 2.00ms | 1.10× | 0.180ms |
-| depth=25 | 1.99ms | 3.07ms | 1.54× | 1.08ms |
-| walk=40 | 71.8ms | 110ms | 1.53× | 37.7ms |
+| Label    | Cursor | Offset | Speedup |     Δ ms |
+| -------- | -----: | -----: | ------: | -------: |
+| depth=0  | 1.49ms | 1.49ms |   1.00× | -0.005ms |
+| depth=5  | 1.53ms | 1.78ms |   1.17× |  0.255ms |
+| depth=10 | 1.82ms | 2.00ms |   1.10× |  0.180ms |
+| depth=25 | 1.99ms | 3.07ms |   1.54× |   1.08ms |
+| walk=40  | 71.8ms |  110ms |   1.53× |   37.7ms |
 
 ### scoreboard
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 1.46ms | 1.48ms | 1.02× | 0.023ms |
-| depth=10 | 1.65ms | 2.00ms | 1.21× | 0.347ms |
-| depth=50 | 1.86ms | 4.92ms | 2.64× | 3.06ms |
-| depth=100 | 2.36ms | 7.76ms | 3.29× | 5.40ms |
-| depth=500 | 5.65ms | 29.9ms | 5.29× | 24.2ms |
-| depth=1000 | 9.41ms | 51.3ms | 5.45× | 41.9ms |
+| Label      | Cursor | Offset | Speedup |    Δ ms |
+| ---------- | -----: | -----: | ------: | ------: |
+| depth=0    | 1.46ms | 1.48ms |   1.02× | 0.023ms |
+| depth=10   | 1.65ms | 2.00ms |   1.21× | 0.347ms |
+| depth=50   | 1.86ms | 4.92ms |   2.64× |  3.06ms |
+| depth=100  | 2.36ms | 7.76ms |   3.29× |  5.40ms |
+| depth=500  | 5.65ms | 29.9ms |   5.29× |  24.2ms |
+| depth=1000 | 9.41ms | 51.3ms |   5.45× |  41.9ms |
 
 ### ideal-baseline
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 1.32ms | 1.33ms | 1.01× | 0.007ms |
-| depth=50 | 1.88ms | 4.60ms | 2.44× | 2.71ms |
-| depth=100 | 2.36ms | 7.01ms | 2.96× | 4.64ms |
-| depth=500 | 6.31ms | 27.1ms | 4.30× | 20.8ms |
-| depth=1000 | 12.0ms | 47.1ms | 3.92× | 35.1ms |
+| Label      | Cursor | Offset | Speedup |    Δ ms |
+| ---------- | -----: | -----: | ------: | ------: |
+| depth=0    | 1.32ms | 1.33ms |   1.01× | 0.007ms |
+| depth=50   | 1.88ms | 4.60ms |   2.44× |  2.71ms |
+| depth=100  | 2.36ms | 7.01ms |   2.96× |  4.64ms |
+| depth=500  | 6.31ms | 27.1ms |   4.30× |  20.8ms |
+| depth=1000 | 12.0ms | 47.1ms |   3.92× |  35.1ms |
 
 ## sqlite
 
 ### deep-page
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.363ms | 0.247ms | 0.68× | -0.116ms |
-| depth=10 | 0.307ms | 0.214ms | 0.70× | -0.092ms |
-| depth=50 | 0.291ms | 0.235ms | 0.81× | -0.055ms |
-| depth=100 | 0.291ms | 0.252ms | 0.86× | -0.040ms |
-| depth=500 | 0.233ms | 0.472ms | 2.03× | 0.239ms |
-| depth=1000 | 0.198ms | 0.753ms | 3.81× | 0.555ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.363ms | 0.247ms |   0.68× | -0.116ms |
+| depth=10   | 0.307ms | 0.214ms |   0.70× | -0.092ms |
+| depth=50   | 0.291ms | 0.235ms |   0.81× | -0.055ms |
+| depth=100  | 0.291ms | 0.252ms |   0.86× | -0.040ms |
+| depth=500  | 0.233ms | 0.472ms |   2.03× |  0.239ms |
+| depth=1000 | 0.198ms | 0.753ms |   3.81× |  0.555ms |
 
 ### sequential-walk
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| walk=40 | 8.55ms | 5.59ms | 0.65× | -2.957ms |
+| Label   | Cursor | Offset | Speedup |     Δ ms |
+| ------- | -----: | -----: | ------: | -------: |
+| walk=40 | 8.55ms | 5.59ms |   0.65× | -2.957ms |
 
 ### filtered-feed
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.152ms | 0.149ms | 0.98× | -0.002ms |
-| depth=10 | 0.335ms | 0.284ms | 0.85× | -0.052ms |
-| depth=50 | 0.211ms | 0.199ms | 0.94× | -0.013ms |
-| depth=100 | 0.209ms | 0.244ms | 1.17× | 0.035ms |
-| depth=500 | 0.203ms | 0.639ms | 3.15× | 0.436ms |
-| depth=1000 | 0.179ms | 1.12ms | 6.27× | 0.944ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.152ms | 0.149ms |   0.98× | -0.002ms |
+| depth=10   | 0.335ms | 0.284ms |   0.85× | -0.052ms |
+| depth=50   | 0.211ms | 0.199ms |   0.94× | -0.013ms |
+| depth=100  | 0.209ms | 0.244ms |   1.17× |  0.035ms |
+| depth=500  | 0.203ms | 0.639ms |   3.15× |  0.436ms |
+| depth=1000 | 0.179ms |  1.12ms |   6.27× |  0.944ms |
 
 ### author-timeline
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.131ms | 0.129ms | 0.99× | -0.001ms |
-| depth=5 | 0.177ms | 0.129ms | 0.73× | -0.048ms |
-| depth=10 | 0.357ms | 0.156ms | 0.44× | -0.202ms |
-| depth=25 | 0.180ms | 0.146ms | 0.81× | -0.035ms |
-| walk=40 | 7.25ms | 7.05ms | 0.97× | -0.194ms |
+| Label    |  Cursor |  Offset | Speedup |     Δ ms |
+| -------- | ------: | ------: | ------: | -------: |
+| depth=0  | 0.131ms | 0.129ms |   0.99× | -0.001ms |
+| depth=5  | 0.177ms | 0.129ms |   0.73× | -0.048ms |
+| depth=10 | 0.357ms | 0.156ms |   0.44× | -0.202ms |
+| depth=25 | 0.180ms | 0.146ms |   0.81× | -0.035ms |
+| walk=40  |  7.25ms |  7.05ms |   0.97× | -0.194ms |
 
 ### scoreboard
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.134ms | 0.127ms | 0.95× | -0.006ms |
-| depth=10 | 0.234ms | 0.146ms | 0.62× | -0.088ms |
-| depth=50 | 0.197ms | 0.211ms | 1.07× | 0.014ms |
-| depth=100 | 0.312ms | 0.313ms | 1.00× | 0.001ms |
-| depth=500 | 0.179ms | 0.543ms | 3.04× | 0.364ms |
-| depth=1000 | 0.180ms | 0.829ms | 4.61× | 0.649ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.134ms | 0.127ms |   0.95× | -0.006ms |
+| depth=10   | 0.234ms | 0.146ms |   0.62× | -0.088ms |
+| depth=50   | 0.197ms | 0.211ms |   1.07× |  0.014ms |
+| depth=100  | 0.312ms | 0.313ms |   1.00× |  0.001ms |
+| depth=500  | 0.179ms | 0.543ms |   3.04× |  0.364ms |
+| depth=1000 | 0.180ms | 0.829ms |   4.61× |  0.649ms |
 
 ### ideal-baseline
 
-| Label | Cursor | Offset | Speedup | Δ ms |
-| --- | ---: | ---: | ---: | ---: |
-| depth=0 | 0.094ms | 0.072ms | 0.76× | -0.023ms |
-| depth=50 | 0.109ms | 0.104ms | 0.96× | -0.004ms |
-| depth=100 | 0.113ms | 0.139ms | 1.23× | 0.026ms |
-| depth=500 | 0.101ms | 0.402ms | 3.99× | 0.301ms |
-| depth=1000 | 0.095ms | 0.684ms | 7.24× | 0.590ms |
+| Label      |  Cursor |  Offset | Speedup |     Δ ms |
+| ---------- | ------: | ------: | ------: | -------: |
+| depth=0    | 0.094ms | 0.072ms |   0.76× | -0.023ms |
+| depth=50   | 0.109ms | 0.104ms |   0.96× | -0.004ms |
+| depth=100  | 0.113ms | 0.139ms |   1.23× |  0.026ms |
+| depth=500  | 0.101ms | 0.402ms |   3.99× |  0.301ms |
+| depth=1000 | 0.095ms | 0.684ms |   7.24× |  0.590ms |
 
 ## Deep-page growth
 

--- a/bench/src/compare.ts
+++ b/bench/src/compare.ts
@@ -125,104 +125,68 @@ const formatRatio = (r: number): string => {
   return `${r.toFixed(2)}× (${sign}${pct.toFixed(0)}%)`
 }
 
-const formatConfigLine = (b: BaselineReport): string => {
-  const c = b.config
-  const sha = b.gitSha ? ` · sha \`${b.gitSha.slice(0, 7)}\`` : ''
-  return (
-    `${c.rowCount.toLocaleString()} rows · page ${c.pageSize} · ` +
-    `iters ${c.iterations}/${c.warmup} · walk ${c.walkPages} · ` +
-    `depths [${c.deepPageDepths.join(',')}] · ${c.dialects.join(', ')}${sha}`
-  )
-}
+const shortSha = (b: BaselineReport): string => (b.gitSha ? b.gitSha.slice(0, 7) : '—')
 
-/** Concise markdown for PR comments and CI logs. */
+const deltaRow = (d: CellDelta): string =>
+  `| ${d.dialect} | ${d.scenario} | ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)} |`
+
+const DELTA_HEADER = '| Dialect | Scenario | Label | Base | Curr | Δ |\n| --- | --- | --- | ---: | ---: | ---: |'
+
+/** Short markdown for PR sticky comments and CI logs (not a full matrix dump). */
 export const renderCompareMarkdown = (result: CompareResult): string => {
   const lines: string[] = []
   const { baseline, current, threshold, matched, regressions, improvements } = result
   const gated = gatingRegressions(result)
   const noise = regressions.filter((d) => !isGatingRegression(d))
-
-  // Dialect list may be a subset (matrix jobs); only shape fields gate ratio meaning.
   const configMismatch = configShapeKey(baseline.config) !== configShapeKey(current.config)
+
+  const status =
+    gated.length > 0
+      ? `**⚠️ ${gated.length} CI-gating regression${gated.length === 1 ? '' : 's'}**`
+      : noise.length > 0
+        ? `**✅ no CI-gating regressions** · ${noise.length} noisy cell${noise.length === 1 ? '' : 's'}`
+        : `**✅ no regressions**`
 
   lines.push(`# Benchmark comparison`)
   lines.push('')
   lines.push(
-    gated.length > 0
-      ? `**Status: ⚠️ ${gated.length} CI-gating regression(s)** (library path, depth ≥ ${MIN_GATE_DEPTH} or walks; cursor mean ≥ ${threshold}× baseline)`
-      : regressions.length > 0
-        ? `**Status: ✅ no CI-gating regressions** (${regressions.length} noisy / non-gated cell(s) above ${threshold}× — informational only)`
-        : `**Status: ✅ no regressions** (threshold ${threshold}× on cursor mean)`,
+    `${status} · ≥${threshold}× · \`${shortSha(current)}\` vs baseline \`${shortSha(baseline)}\``,
   )
   if (configMismatch) {
     lines.push('')
-    lines.push('> ⚠️ **Config differs** from baseline — ratios may not be meaningful until configs match.')
+    lines.push('> ⚠️ Config differs from baseline — ratios may not be meaningful.')
   }
-  lines.push('')
-  lines.push(`| | Generated | Config |`)
-  lines.push(`| --- | --- | --- |`)
-  lines.push(`| **Baseline** | ${baseline.generatedAt} | ${formatConfigLine(baseline)} |`)
-  lines.push(`| **Current** | ${current.generatedAt} | ${formatConfigLine(current)} |`)
-  lines.push('')
-  lines.push(
-    'Primary signal: **cursor mean** latency (library path). Absolute ms varies by runner; ratios vs the committed baseline are what matter. ' +
-      `CI fails only on library scenarios at **depth ≥ ${MIN_GATE_DEPTH}** or sequential walks — not \`ideal-baseline\` or shallow depths.`,
-  )
   lines.push('')
 
   if (gated.length) {
-    lines.push('## CI-gating regressions')
+    lines.push('### CI-gating')
     lines.push('')
-    lines.push('| Dialect | Scenario | Label | Baseline cursor | Current cursor | Δ |')
-    lines.push('| --- | --- | --- | ---: | ---: | ---: |')
-    for (const d of gated) {
-      lines.push(
-        `| ${d.dialect} | ${d.scenario} | ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)} |`,
-      )
-    }
+    lines.push(DELTA_HEADER)
+    for (const d of gated) lines.push(deltaRow(d))
     lines.push('')
   }
 
   if (noise.length) {
-    lines.push('## Noisy / non-gated (informational)')
+    lines.push(`### Noisy (not gated)${noise.length > 5 ? ` · ${noise.length}` : ''}`)
     lines.push('')
-    lines.push(
-      `_Ideal-baseline and shallow depths (depth < ${MIN_GATE_DEPTH}) do not fail CI — runner jitter often dominates sub-ms cells._`,
-    )
-    lines.push('')
-    lines.push('| Dialect | Scenario | Label | Baseline cursor | Current cursor | Δ |')
-    lines.push('| --- | --- | --- | ---: | ---: | ---: |')
-    for (const d of noise) {
-      lines.push(
-        `| ${d.dialect} | ${d.scenario} | ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)} |`,
-      )
-    }
+    lines.push(DELTA_HEADER)
+    for (const d of noise.slice(0, 5)) lines.push(deltaRow(d))
+    if (noise.length > 5) lines.push(`_…${noise.length - 5} more_`)
     lines.push('')
   }
 
   if (improvements.length) {
-    lines.push('## Improvements')
+    const top = improvements.slice(0, 5)
+    lines.push(`### Improvements · top ${top.length} of ${improvements.length}`)
     lines.push('')
-    lines.push('| Dialect | Scenario | Label | Baseline cursor | Current cursor | Δ |')
-    lines.push('| --- | --- | --- | ---: | ---: | ---: |')
-    for (const d of improvements.slice(0, 20)) {
-      lines.push(
-        `| ${d.dialect} | ${d.scenario} | ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)} |`,
-      )
-    }
-    if (improvements.length > 20) {
-      lines.push('')
-      lines.push(`_…and ${improvements.length - 20} more_`)
-    }
+    lines.push(DELTA_HEADER)
+    for (const d of top) lines.push(deltaRow(d))
     lines.push('')
   }
 
-  // Headline: deepest deep-page per dialect
-  lines.push('## Headline — deepest deep-page (cursor)')
-  lines.push('')
-  lines.push('| Dialect | Label | Baseline | Current | Δ | Speedup (cur) |')
-  lines.push('| --- | --- | ---: | ---: | ---: | ---: |')
-  const dialects = [...new Set(matched.map((m) => m.dialect))]
+  // One row per dialect: deepest deep-page cursor mean
+  const dialects = [...new Set(matched.map((m) => m.dialect))].sort()
+  const headlines: CellDelta[] = []
   for (const dialect of dialects) {
     const deep = matched
       .filter((m) => m.dialect === dialect && m.scenario === 'deep-page')
@@ -232,66 +196,33 @@ export const renderCompareMarkdown = (result: CompareResult): string => {
         return da - db
       })
     const last = deep[deep.length - 1]
-    if (!last) continue
-    const mark = last.status === 'regression' ? ' ⚠️' : last.status === 'improvement' ? ' ✅' : ''
-    lines.push(
-      `| ${dialect} | ${last.label} | ${formatMs(last.baseline.cursorMean)} | ${formatMs(last.current.cursorMean)} | ${formatRatio(last.cursorRatio)}${mark} | ${formatSpeedup(last.current.speedup)} |`,
-    )
+    if (last) headlines.push(last)
   }
-  lines.push('')
-
-  // Deep-page matrix (compact)
-  lines.push('## Deep-page cursor mean (baseline → current)')
-  lines.push('')
-  for (const dialect of dialects) {
-    const deep = matched
-      .filter((m) => m.dialect === dialect && m.scenario === 'deep-page')
-      .sort((a, b) => {
-        const da = Number(a.label.replace(/\D/g, '')) || 0
-        const db = Number(b.label.replace(/\D/g, '')) || 0
-        return da - db
-      })
-    if (!deep.length) continue
-    lines.push(`### ${dialect}`)
+  if (headlines.length) {
+    lines.push('### Deepest deep-page')
     lines.push('')
-    lines.push('| Label | Baseline | Current | Δ | Offset (cur) | Speedup |')
-    lines.push('| --- | ---: | ---: | ---: | ---: | ---: |')
-    for (const d of deep) {
+    lines.push('| Dialect | Label | Base | Curr | Δ | vs offset |')
+    lines.push('| --- | --- | ---: | ---: | ---: | ---: |')
+    for (const d of headlines) {
       const mark = d.status === 'regression' ? ' ⚠️' : d.status === 'improvement' ? ' ✅' : ''
       lines.push(
-        `| ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)}${mark} | ${formatMs(d.current.offsetMean)} | ${formatSpeedup(d.current.speedup)} |`,
+        `| ${d.dialect} | ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)}${mark} | ${formatSpeedup(d.current.speedup)} |`,
       )
     }
     lines.push('')
   }
 
   if (result.missingInCurrent.length || result.newInCurrent.length) {
-    lines.push('## Coverage')
-    lines.push('')
-    if (result.missingInCurrent.length) {
-      lines.push(
-        `- Missing vs baseline (${result.missingInCurrent.length}): ${result.missingInCurrent
-          .slice(0, 8)
-          .map((c) => cellKey(c))
-          .join(', ')}${result.missingInCurrent.length > 8 ? '…' : ''}`,
-      )
-    }
-    if (result.newInCurrent.length) {
-      lines.push(
-        `- New cells (${result.newInCurrent.length}): ${result.newInCurrent
-          .slice(0, 8)
-          .map((c) => cellKey(c))
-          .join(', ')}${result.newInCurrent.length > 8 ? '…' : ''}`,
-      )
-    }
+    const miss = result.missingInCurrent.length
+    const neu = result.newInCurrent.length
+    lines.push(
+      `_Coverage: ${miss ? `${miss} missing` : ''}${miss && neu ? ', ' : ''}${neu ? `${neu} new` : ''}._`,
+    )
     lines.push('')
   }
 
-  lines.push('---')
-  lines.push('')
   lines.push(
-    `_CI gate: library scenarios, depth ≥ ${MIN_GATE_DEPTH} or \`walk=*\`, cursor mean ≥ ${threshold}× baseline. ` +
-      `See \`bench/README.md\`._`,
+    `_Gate: library · depth ≥ ${MIN_GATE_DEPTH} or walk · cursor mean ≥ ${threshold}× · [bench/README.md](bench/README.md)_`,
   )
   lines.push('')
 

--- a/bench/src/compare.ts
+++ b/bench/src/compare.ts
@@ -4,6 +4,15 @@ import { formatMs, formatSpeedup } from './metrics.js'
 
 export const DEFAULT_REGRESSION_THRESHOLD = 1.5
 
+/**
+ * Shallow depths and sub-ms cells are dominated by runner noise on GHA.
+ * Only enforce fail-on-regression for library pages at this depth and deeper.
+ */
+export const MIN_GATE_DEPTH = 100
+
+/** Raw SQL ceiling — informative, not a library regression signal. */
+const NON_GATING_SCENARIOS = new Set(['ideal-baseline'])
+
 const safeRatio = (current: number, baseline: number): number => {
   if (!Number.isFinite(current) || !Number.isFinite(baseline) || baseline <= 0) {
     return Number.NaN
@@ -17,6 +26,27 @@ const statusFor = (cursorRatio: number, threshold: number): CellDelta['status'] 
   if (cursorRatio <= 1 / threshold) return 'improvement'
   return 'stable'
 }
+
+/**
+ * Whether a cell regression should fail CI (`--fail-on-regression`).
+ * Still listed in the report when true or false; only gating ones set exit 1.
+ */
+export const isGatingRegression = (d: CellDelta): boolean => {
+  if (d.status !== 'regression') return false
+  if (NON_GATING_SCENARIOS.has(d.scenario)) return false
+
+  const depthMatch = /^depth=(\d+)$/.exec(d.label)
+  if (depthMatch) {
+    return Number(depthMatch[1]) >= MIN_GATE_DEPTH
+  }
+
+  // sequential-walk / author walk labels (`walk=N`) — gate these.
+  if (d.label.startsWith('walk=')) return true
+
+  return true
+}
+
+export const gatingRegressions = (result: CompareResult): CellDelta[] => result.regressions.filter(isGatingRegression)
 
 /** Shape fields that must match for ratios to be meaningful (dialect list excluded). */
 export const configShapeKey = (
@@ -109,17 +139,20 @@ const formatConfigLine = (b: BaselineReport): string => {
 export const renderCompareMarkdown = (result: CompareResult): string => {
   const lines: string[] = []
   const { baseline, current, threshold, matched, regressions, improvements } = result
+  const gated = gatingRegressions(result)
+  const noise = regressions.filter((d) => !isGatingRegression(d))
 
-  const hasFail = regressions.length > 0
   // Dialect list may be a subset (matrix jobs); only shape fields gate ratio meaning.
   const configMismatch = configShapeKey(baseline.config) !== configShapeKey(current.config)
 
   lines.push(`# Benchmark comparison`)
   lines.push('')
   lines.push(
-    hasFail
-      ? `**Status: ⚠️ ${regressions.length} regression(s)** (cursor mean ≥ ${threshold}× baseline)`
-      : `**Status: ✅ no regressions** (threshold ${threshold}× on cursor mean)`,
+    gated.length > 0
+      ? `**Status: ⚠️ ${gated.length} CI-gating regression(s)** (library path, depth ≥ ${MIN_GATE_DEPTH} or walks; cursor mean ≥ ${threshold}× baseline)`
+      : regressions.length > 0
+        ? `**Status: ✅ no CI-gating regressions** (${regressions.length} noisy / non-gated cell(s) above ${threshold}× — informational only)`
+        : `**Status: ✅ no regressions** (threshold ${threshold}× on cursor mean)`,
   )
   if (configMismatch) {
     lines.push('')
@@ -132,16 +165,34 @@ export const renderCompareMarkdown = (result: CompareResult): string => {
   lines.push(`| **Current** | ${current.generatedAt} | ${formatConfigLine(current)} |`)
   lines.push('')
   lines.push(
-    'Primary signal: **cursor mean** latency (library path). Absolute ms varies by runner; ratios vs the committed baseline are what matter.',
+    'Primary signal: **cursor mean** latency (library path). Absolute ms varies by runner; ratios vs the committed baseline are what matter. ' +
+      `CI fails only on library scenarios at **depth ≥ ${MIN_GATE_DEPTH}** or sequential walks — not \`ideal-baseline\` or shallow depths.`,
   )
   lines.push('')
 
-  if (regressions.length) {
-    lines.push('## Regressions')
+  if (gated.length) {
+    lines.push('## CI-gating regressions')
     lines.push('')
     lines.push('| Dialect | Scenario | Label | Baseline cursor | Current cursor | Δ |')
     lines.push('| --- | --- | --- | ---: | ---: | ---: |')
-    for (const d of regressions) {
+    for (const d of gated) {
+      lines.push(
+        `| ${d.dialect} | ${d.scenario} | ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)} |`,
+      )
+    }
+    lines.push('')
+  }
+
+  if (noise.length) {
+    lines.push('## Noisy / non-gated (informational)')
+    lines.push('')
+    lines.push(
+      `_Ideal-baseline and shallow depths (depth < ${MIN_GATE_DEPTH}) do not fail CI — runner jitter often dominates sub-ms cells._`,
+    )
+    lines.push('')
+    lines.push('| Dialect | Scenario | Label | Baseline cursor | Current cursor | Δ |')
+    lines.push('| --- | --- | --- | ---: | ---: | ---: |')
+    for (const d of noise) {
       lines.push(
         `| ${d.dialect} | ${d.scenario} | ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)} |`,
       )
@@ -238,10 +289,14 @@ export const renderCompareMarkdown = (result: CompareResult): string => {
 
   lines.push('---')
   lines.push('')
-  lines.push(`_Threshold: cursor mean ≥ ${threshold}× baseline = regression. See \`bench/README.md\`._`)
+  lines.push(
+    `_CI gate: library scenarios, depth ≥ ${MIN_GATE_DEPTH} or \`walk=*\`, cursor mean ≥ ${threshold}× baseline. ` +
+      `See \`bench/README.md\`._`,
+  )
   lines.push('')
 
   return lines.join('\n')
 }
 
-export const hasRegressions = (result: CompareResult): boolean => result.regressions.length > 0
+/** True when any regression should fail `--fail-on-regression` (not all report rows). */
+export const hasRegressions = (result: CompareResult): boolean => gatingRegressions(result).length > 0

--- a/bench/src/compare.ts
+++ b/bench/src/compare.ts
@@ -149,9 +149,7 @@ export const renderCompareMarkdown = (result: CompareResult): string => {
 
   lines.push(`# Benchmark comparison`)
   lines.push('')
-  lines.push(
-    `${status} · ≥${threshold}× · \`${shortSha(current)}\` vs baseline \`${shortSha(baseline)}\``,
-  )
+  lines.push(`${status} · ≥${threshold}× · \`${shortSha(current)}\` vs baseline \`${shortSha(baseline)}\``)
   if (configMismatch) {
     lines.push('')
     lines.push('> ⚠️ Config differs from baseline — ratios may not be meaningful.')
@@ -215,9 +213,7 @@ export const renderCompareMarkdown = (result: CompareResult): string => {
   if (result.missingInCurrent.length || result.newInCurrent.length) {
     const miss = result.missingInCurrent.length
     const neu = result.newInCurrent.length
-    lines.push(
-      `_Coverage: ${miss ? `${miss} missing` : ''}${miss && neu ? ', ' : ''}${neu ? `${neu} new` : ''}._`,
-    )
+    lines.push(`_Coverage: ${miss ? `${miss} missing` : ''}${miss && neu ? ', ' : ''}${neu ? `${neu} new` : ''}._`)
     lines.push('')
   }
 

--- a/bench/src/index.ts
+++ b/bench/src/index.ts
@@ -3,7 +3,13 @@ import { access, readdir, stat } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 
 import { DEFAULT_BASELINE_DIR, DEFAULT_BASELINE_JSON, loadBaseline, mergeBaselines, writeBaseline } from './baseline.js'
-import { compareBaselines, DEFAULT_REGRESSION_THRESHOLD, hasRegressions, renderCompareMarkdown } from './compare.js'
+import {
+  compareBaselines,
+  DEFAULT_REGRESSION_THRESHOLD,
+  gatingRegressions,
+  hasRegressions,
+  renderCompareMarkdown,
+} from './compare.js'
 import { describeConfig, parseArgs } from './config.js'
 import { renderBaselineMarkdown, renderConsole, writeReports } from './report.js'
 import type { BaselineReport, BenchReport } from './types.js'
@@ -236,8 +242,10 @@ const runCompare = async (opts: {
   }
 
   if (enforce && hasRegressions(result)) {
+    const n = gatingRegressions(result).length
     console.error(
-      `\nBenchmark regression: ${result.regressions.length} cell(s) ≥ ${opts.threshold}× baseline cursor mean.`,
+      `\nBenchmark regression: ${n} CI-gating cell(s) ≥ ${opts.threshold}× baseline cursor mean ` +
+        `(library path, depth ≥ 100 or walks; ideal-baseline / shallow depths ignored).`,
     )
     process.exitCode = 1
   }


### PR DESCRIPTION
Only fail CI on library-path regressions at depth ≥ 100 or sequential walks. Ideal-baseline and shallow depths remain in the sticky report as informational so sub-ms runner noise does not fail the job.