### PR TITLE
feat(bench): Chart.js PNG deep-page curves in PR comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,42 @@ jobs:
           fi
           mkdir -p bench/results
           # pnpm --filter runs with cwd=bench/; use absolute merge paths.
+          # Writes pr-comment.md + results/charts/*.png (Chart.js PNGs).
           pnpm --filter kysely-cursor-bench bench -- \
             --merge "${{ github.workspace }}/bench/artifacts" \
             --git-sha "${{ github.sha }}" \
             --compare \
             --threshold 1.5 \
             --comment-out results/pr-comment.md
+
+      # Sticky PR comments need absolute image URLs. Publish Chart.js PNGs to a
+      # per-PR orphan-ish branch and rewrite markdown to raw.githubusercontent.com.
+      - name: Publish chart images for PR comment
+        if: github.event_name == 'pull_request' && hashFiles('bench/results/charts/*.png') != ''
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR="${{ github.event.pull_request.number }}"
+          REF="refs/heads/bench-charts/pr-${PR}"
+          WORK=/tmp/bench-chart-publish
+          rm -rf "$WORK"
+          mkdir -p "$WORK"
+          cp bench/results/charts/*.png "$WORK/"
+          cd "$WORK"
+          git init -q
+          git checkout -q -b "pr-${PR}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add *.png
+          git commit -q -m "bench charts for PR ${PR} @ ${{ github.sha }}"
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git push -qf origin "HEAD:${REF}"
+          BASE="https://raw.githubusercontent.com/${{ github.repository }}/bench-charts/pr-${PR}"
+          # Relative charts/… → absolute raw URLs for the sticky comment.
+          sed -i "s|(charts/|(${BASE}/|g" "${{ github.workspace }}/bench/results/pr-comment.md"
+          echo "Chart base URL: ${BASE}"
 
       - name: Upload merged bench artifacts
         if: always()

--- a/bench/README.md
+++ b/bench/README.md
@@ -269,7 +269,8 @@ Benchmarks run as a **dialect matrix** in `.github/workflows/ci.yml`
    deep/walk cells) when the baseline was produced on CI (`gitSha` set).
 2. **Bench report** downloads all dialect artifacts, merges them with
    `--merge bench/artifacts`, and:
-   - On **pull_request**: posts a sticky PR comment with the combined compare report.
+   - On **pull_request**: posts a sticky PR comment with the combined compare report
+     (per-dialect **Chart.js PNG** deep-page curves + sequential-walk table).
    - On **push to main** (only if every matrix leg succeeded): writes
      `bench/baseline/*` and commits `chore(bench): update baseline [skip ci]`.
 

--- a/bench/package.json
+++ b/bench/package.json
@@ -15,10 +15,12 @@
     "bench:sqlite": "tsx src/index.ts --dialect sqlite"
   },
   "dependencies": {
+    "@napi-rs/canvas": "^1.0.2",
     "@testcontainers/mssqlserver": "^12.0.4",
     "@testcontainers/mysql": "^12.0.4",
     "@testcontainers/postgresql": "^12.0.4",
     "better-sqlite3": "^12.11.1",
+    "chart.js": "^4.5.1",
     "kysely": "^0.29.4",
     "kysely-cursor": "workspace:*",
     "mssql": "^12.7.0",

--- a/bench/src/chart.ts
+++ b/bench/src/chart.ts
@@ -1,0 +1,156 @@
+/**
+ * Deep-page compare charts as real PNG images (Chart.js + @napi-rs/canvas).
+ * Kept free of kysely-cursor imports so unit tests typecheck without dist/.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { createCanvas } from '@napi-rs/canvas'
+import {
+  CategoryScale,
+  Chart,
+  Filler,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  Title,
+} from 'chart.js'
+
+Chart.register(LineController, LineElement, PointElement, LinearScale, CategoryScale, Legend, Title, Filler)
+
+export type DepthSeriesPoint = {
+  depth: number
+  baselineMs: number
+  currentMs: number
+}
+
+export type DialectDeepPageChart = {
+  dialect: string
+  points: DepthSeriesPoint[]
+}
+
+/** Round for table legends. */
+export const chartNum = (ms: number): string => {
+  if (!Number.isFinite(ms)) return '0'
+  if (ms >= 100) return ms.toFixed(0)
+  if (ms >= 10) return ms.toFixed(1)
+  if (ms >= 1) return ms.toFixed(2)
+  return ms.toFixed(3)
+}
+
+const CHART_W = 360
+const CHART_H = 200
+
+/** Render one dialect deep-page baseline-vs-current line chart to PNG. */
+export const renderDeepPagePng = async (dialect: string, points: DepthSeriesPoint[]): Promise<Buffer> => {
+  const ordered = [...points].sort((a, b) => a.depth - b.depth)
+  const canvas = createCanvas(CHART_W, CHART_H)
+  const ctx = canvas.getContext('2d')
+
+  // Opaque white background (GitHub / dark mode friendly borders).
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(0, 0, CHART_W, CHART_H)
+
+  const chart = new Chart(ctx as unknown as CanvasRenderingContext2D, {
+    type: 'line',
+    data: {
+      labels: ordered.map((p) => String(p.depth)),
+      datasets: [
+        {
+          label: 'baseline',
+          data: ordered.map((p) => p.baselineMs),
+          borderColor: '#6b7280',
+          backgroundColor: 'rgba(107, 114, 128, 0.06)',
+          borderWidth: 2,
+          pointRadius: 3,
+          pointHoverRadius: 4,
+          tension: 0.25,
+          fill: false,
+        },
+        {
+          label: 'current',
+          data: ordered.map((p) => p.currentMs),
+          borderColor: '#2563eb',
+          backgroundColor: 'rgba(37, 99, 235, 0.06)',
+          borderWidth: 2,
+          pointRadius: 3,
+          pointHoverRadius: 4,
+          tension: 0.25,
+          fill: false,
+        },
+      ],
+    },
+    options: {
+      responsive: false,
+      animation: false,
+      devicePixelRatio: 2,
+      layout: { padding: { top: 4, right: 8, bottom: 0, left: 4 } },
+      plugins: {
+        title: {
+          display: true,
+          text: `${dialect} · deep-page (ms)`,
+          font: { size: 12, weight: 'bold' },
+          color: '#111827',
+          padding: { bottom: 6 },
+        },
+        legend: {
+          position: 'bottom',
+          labels: { boxWidth: 10, boxHeight: 10, font: { size: 10 }, color: '#374151', padding: 8 },
+        },
+      },
+      scales: {
+        x: {
+          title: { display: true, text: 'depth', font: { size: 10 }, color: '#6b7280' },
+          ticks: { font: { size: 10 }, color: '#4b5563' },
+          grid: { color: 'rgba(0,0,0,0.06)' },
+        },
+        y: {
+          beginAtZero: true,
+          title: { display: true, text: 'ms', font: { size: 10 }, color: '#6b7280' },
+          ticks: { font: { size: 10 }, color: '#4b5563' },
+          grid: { color: 'rgba(0,0,0,0.06)' },
+        },
+      },
+    },
+  })
+
+  chart.update('none')
+  const buf = Buffer.from(canvas.toBuffer('image/png'))
+  chart.destroy()
+  return buf
+}
+
+/** Write one PNG per dialect; returns map dialect → absolute file path. */
+export const writeDeepPageCharts = async (
+  charts: DialectDeepPageChart[],
+  outDir: string,
+): Promise<Map<string, string>> => {
+  await mkdir(outDir, { recursive: true })
+  const paths = new Map<string, string>()
+  for (const { dialect, points } of charts) {
+    if (points.length === 0) continue
+    const file = join(outDir, `${dialect}.png`)
+    const png = await renderDeepPagePng(dialect, points)
+    await writeFile(file, png)
+    paths.set(dialect, file)
+  }
+  return paths
+}
+
+/**
+ * 2×2 markdown image grid. `urlFor(dialect)` must return an https URL for
+ * GitHub sticky comments (relative paths do not load there).
+ */
+export const renderDeepPageImageGrid = (dialects: string[], urlFor: (dialect: string) => string): string => {
+  if (dialects.length === 0) return ''
+
+  const cell = (d: string | undefined): string => (d ? `![${d} deep-page](${urlFor(d)})` : ' ')
+
+  const rows: string[] = ['| | |', '| :---: | :---: |']
+  for (let i = 0; i < dialects.length; i += 2) {
+    rows.push(`| ${cell(dialects[i])} | ${cell(dialects[i + 1])} |`)
+  }
+  return rows.join('\n')
+}

--- a/bench/src/compare.ts
+++ b/bench/src/compare.ts
@@ -1,5 +1,6 @@
 import type { BaselineCell, BaselineReport, CellDelta, CompareResult } from './types.js'
 import { cellKey } from './baseline.js'
+import { renderDeepPageImageGrid, type DepthSeriesPoint } from './chart.js'
 import { DEFAULT_REGRESSION_THRESHOLD, isGatingRegression, MIN_ABS_MS, MIN_GATE_DEPTH } from './gate.js'
 import { formatMs, formatSpeedup } from './metrics.js'
 
@@ -11,6 +12,7 @@ export {
   MIN_ABS_MS,
   MIN_GATE_DEPTH,
 } from './gate.js'
+export { renderDeepPageImageGrid, renderDeepPagePng, writeDeepPageCharts } from './chart.js'
 
 const safeRatio = (current: number, baseline: number): number => {
   if (!Number.isFinite(current) || !Number.isFinite(baseline) || baseline <= 0) {
@@ -112,20 +114,48 @@ const deltaRow = (d: CellDelta): string =>
 
 const DELTA_HEADER = '| Dialect | Scenario | Label | Base | Curr | Δ |\n| --- | --- | --- | ---: | ---: | ---: |'
 
+const parseDepth = (label: string): number | null => {
+  const m = /^depth=(\d+)$/.exec(label)
+  return m ? Number(m[1]) : null
+}
+
+/** Deep-page matched cells → series points (ascending depth). */
+export const deepPageSeries = (matched: CellDelta[], dialect: string): DepthSeriesPoint[] =>
+  matched
+    .filter((m) => m.dialect === dialect && m.scenario === 'deep-page')
+    .map((m) => {
+      const depth = parseDepth(m.label)
+      if (depth === null) return null
+      return {
+        depth,
+        baselineMs: m.baseline.cursorMean,
+        currentMs: m.current.cursorMean,
+      }
+    })
+    .filter((p): p is DepthSeriesPoint => p !== null)
+    .sort((a, b) => a.depth - b.depth)
+
+export type CompareMarkdownOpts = {
+  /**
+   * Base URL or relative path for chart PNGs (no trailing slash).
+   * Local default: `charts` (next to the comment file).
+   * CI sticky comments need an https:// raw.githubusercontent.com/... base.
+   */
+  chartUrlBase?: string
+}
+
 /** Short markdown for PR sticky comments and CI logs (not a full matrix dump). */
-export const renderCompareMarkdown = (result: CompareResult): string => {
+export const renderCompareMarkdown = (result: CompareResult, opts: CompareMarkdownOpts = {}): string => {
   const lines: string[] = []
-  const { baseline, current, threshold, matched, regressions, improvements } = result
+  const { baseline, current, threshold, matched } = result
   const gated = gatingRegressions(result)
-  const noise = regressions.filter((d) => !isGatingRegression(d))
   const configMismatch = configShapeKey(baseline.config) !== configShapeKey(current.config)
+  const chartUrlBase = opts.chartUrlBase ?? 'charts'
 
   const status =
     gated.length > 0
       ? `**⚠️ ${gated.length} CI-gating regression${gated.length === 1 ? '' : 's'}**`
-      : noise.length > 0
-        ? `**✅ no CI-gating regressions** · ${noise.length} noisy cell${noise.length === 1 ? '' : 's'}`
-        : `**✅ no regressions**`
+      : `**✅ no CI-gating regressions**`
 
   lines.push(`# Benchmark comparison`)
   lines.push('')
@@ -144,44 +174,47 @@ export const renderCompareMarkdown = (result: CompareResult): string => {
     lines.push('')
   }
 
-  if (noise.length) {
-    lines.push(`### Noisy / weak (not gated)${noise.length > 5 ? ` · ${noise.length}` : ''}`)
-    lines.push('')
-    lines.push(DELTA_HEADER)
-    for (const d of noise.slice(0, 5)) lines.push(deltaRow(d))
-    if (noise.length > 5) lines.push(`_…${noise.length - 5} more_`)
-    lines.push('')
-  }
-
-  if (improvements.length) {
-    const top = improvements.slice(0, 5)
-    lines.push(`### Improvements · top ${top.length} of ${improvements.length}`)
-    lines.push('')
-    lines.push(DELTA_HEADER)
-    for (const d of top) lines.push(deltaRow(d))
-    lines.push('')
-  }
-
-  // One row per dialect: deepest deep-page cursor mean
   const dialects = [...new Set(matched.map((m) => m.dialect))].sort()
-  const headlines: CellDelta[] = []
-  for (const dialect of dialects) {
-    const deep = matched
-      .filter((m) => m.dialect === dialect && m.scenario === 'deep-page')
-      .sort((a, b) => {
-        const da = Number(a.label.replace(/\D/g, '')) || 0
-        const db = Number(b.label.replace(/\D/g, '')) || 0
-        return da - db
-      })
-    const last = deep[deep.length - 1]
-    if (last) headlines.push(last)
+  const deepCharts = dialects
+    .map((dialect) => ({ dialect, points: deepPageSeries(matched, dialect) }))
+    .filter((c) => c.points.length > 0)
+
+  if (deepCharts.length) {
+    lines.push('### Deep-page')
+    lines.push('')
+    lines.push(
+      renderDeepPageImageGrid(
+        deepCharts.map((c) => c.dialect),
+        (d) => `${chartUrlBase}/${d}.png`,
+      ),
+    )
+    lines.push('')
+    lines.push('| Dialect | Depth | Base | Curr | Δ | vs offset |')
+    lines.push('| --- | ---: | ---: | ---: | ---: | ---: |')
+    for (const { dialect, points } of deepCharts) {
+      for (const p of points) {
+        const cell = matched.find(
+          (m) => m.dialect === dialect && m.scenario === 'deep-page' && m.label === `depth=${p.depth}`,
+        )
+        if (!cell) continue
+        const mark = cell.status === 'regression' ? ' ⚠️' : cell.status === 'improvement' ? ' ✅' : ''
+        lines.push(
+          `| ${dialect} | ${p.depth} | ${formatMs(p.baselineMs)} | ${formatMs(p.currentMs)} | ${formatRatio(cell.cursorRatio)}${mark} | ${formatSpeedup(cell.current.speedup)} |`,
+        )
+      }
+    }
+    lines.push('')
   }
-  if (headlines.length) {
-    lines.push('### Deepest deep-page')
+
+  const walks = matched
+    .filter((m) => m.scenario === 'sequential-walk')
+    .sort((a, b) => a.dialect.localeCompare(b.dialect) || a.label.localeCompare(b.label))
+  if (walks.length) {
+    lines.push('### Sequential-walk')
     lines.push('')
     lines.push('| Dialect | Label | Base | Curr | Δ | vs offset |')
     lines.push('| --- | --- | ---: | ---: | ---: | ---: |')
-    for (const d of headlines) {
+    for (const d of walks) {
       const mark = d.status === 'regression' ? ' ⚠️' : d.status === 'improvement' ? ' ✅' : ''
       lines.push(
         `| ${d.dialect} | ${d.label} | ${formatMs(d.baseline.cursorMean)} | ${formatMs(d.current.cursorMean)} | ${formatRatio(d.cursorRatio)}${mark} | ${formatSpeedup(d.current.speedup)} |`,

--- a/bench/src/index.ts
+++ b/bench/src/index.ts
@@ -5,11 +5,13 @@ import { join, resolve } from 'node:path'
 import { DEFAULT_BASELINE_DIR, DEFAULT_BASELINE_JSON, loadBaseline, mergeBaselines, writeBaseline } from './baseline.js'
 import {
   compareBaselines,
+  deepPageSeries,
   DEFAULT_REGRESSION_THRESHOLD,
   gatingRegressions,
   hasRegressions,
   renderCompareMarkdown,
 } from './compare.js'
+import { writeDeepPageCharts } from './chart.js'
 import { describeConfig, parseArgs } from './config.js'
 import { renderBaselineMarkdown, renderConsole, writeReports } from './report.js'
 import type { BaselineReport, BenchReport } from './types.js'
@@ -222,13 +224,27 @@ const runCompare = async (opts: {
 }) => {
   const baseline = await loadBaseline(opts.baselinePath)
   const result = compareBaselines(baseline, opts.current, opts.threshold)
-  const md = renderCompareMarkdown(result)
+
+  // Chart.js PNG deep-page plots (baseline vs current) next to the comment / results.
+  const { writeFile, mkdir } = await import('node:fs/promises')
+  const { dirname, join } = await import('node:path')
+  const chartDir = opts.commentOut ? join(dirname(opts.commentOut), 'charts') : join(process.cwd(), 'results', 'charts')
+  const dialects = [...new Set(result.matched.map((m) => m.dialect))].sort()
+  const deepCharts = dialects
+    .map((dialect) => ({ dialect, points: deepPageSeries(result.matched, dialect) }))
+    .filter((c) => c.points.length > 0)
+  if (deepCharts.length) {
+    await writeDeepPageCharts(deepCharts, chartDir)
+    console.log(`Deep-page charts written: ${chartDir}`)
+  }
+
+  // Relative `charts/` works for local preview; CI rewrites to raw.githubusercontent.com.
+  const chartUrlBase = process.env.BENCH_CHART_URL_BASE?.replace(/\/$/, '') || 'charts'
+  const md = renderCompareMarkdown(result, { chartUrlBase })
 
   process.stdout.write(`\n${md}\n`)
 
   if (opts.commentOut) {
-    const { writeFile, mkdir } = await import('node:fs/promises')
-    const { dirname } = await import('node:path')
     await mkdir(dirname(opts.commentOut), { recursive: true })
     await writeFile(opts.commentOut, md, 'utf8')
     console.log(`Compare comment written: ${opts.commentOut}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
 
   bench:
     dependencies:
+      '@napi-rs/canvas':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@testcontainers/mssqlserver':
         specifier: ^12.0.4
         version: 12.0.4
@@ -111,6 +114,9 @@ importers:
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
+      chart.js:
+        specifier: ^4.5.1
+        version: 4.5.1
       kysely:
         specifier: ^0.29.4
         version: 0.29.4
@@ -901,6 +907,9 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
@@ -909,6 +918,81 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.2':
+    resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1577,6 +1661,10 @@ packages:
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
 
+  chart.js@4.5.1:
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -1930,6 +2018,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globby@11.1.0:
@@ -3626,6 +3715,8 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@kurkle/color@0.3.4': {}
+
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
@@ -3647,6 +3738,53 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas@1.0.2':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-x64': 1.0.2
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.2
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.2
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-musl': 1.0.2
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.2
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4263,6 +4401,10 @@ snapshots:
   chai@6.2.2: {}
 
   chardet@2.1.0: {}
+
+  chart.js@4.5.1:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   chokidar@4.0.3:
     dependencies:

--- a/test/bench-chart.test.ts
+++ b/test/bench-chart.test.ts
@@ -1,0 +1,46 @@
+import { chartNum, renderDeepPageImageGrid, renderDeepPagePng } from '../bench/src/chart.js'
+
+describe('chartNum', () => {
+  it('formats chart numbers by magnitude', () => {
+    expect(chartNum(0.294)).toBe('0.294')
+    expect(chartNum(1.5)).toBe('1.50')
+    expect(chartNum(12.34)).toBe('12.3')
+    expect(chartNum(150.2)).toBe('150')
+  })
+})
+
+describe('renderDeepPageImageGrid', () => {
+  it('lays out four dialects in a 2×2 markdown image table', () => {
+    const md = renderDeepPageImageGrid(['mssql', 'mysql', 'postgres', 'sqlite'], (d) => `charts/${d}.png`)
+
+    expect(md).toContain('| :---: | :---: |')
+    expect(md).toContain('![mssql deep-page](charts/mssql.png)')
+    expect(md).toContain('![sqlite deep-page](charts/sqlite.png)')
+    expect(md.split('\n').filter((l) => l.startsWith('| ![') || l.startsWith('|  ')).length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('pads an odd last cell', () => {
+    const md = renderDeepPageImageGrid(['postgres'], (d) => `https://example.com/${d}.png`)
+    expect(md).toContain('![postgres deep-page](https://example.com/postgres.png)')
+    expect(md).toMatch(/\| {1,3}\|$/)
+  })
+
+  it('returns empty when no dialects', () => {
+    expect(renderDeepPageImageGrid([], () => '')).toBe('')
+  })
+})
+
+describe('renderDeepPagePng', () => {
+  it('renders a PNG buffer for dual series', async () => {
+    const buf = await renderDeepPagePng('postgres', [
+      { depth: 0, baselineMs: 1.18, currentMs: 1.25 },
+      { depth: 100, baselineMs: 0.757, currentMs: 0.729 },
+      { depth: 500, baselineMs: 0.594, currentMs: 0.587 },
+    ])
+
+    expect(Buffer.isBuffer(buf)).toBe(true)
+    expect(buf.length).toBeGreaterThan(1000)
+    // PNG signature
+    expect(buf.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+  })
+})


### PR DESCRIPTION
## Summary

- Sticky PR compare comment shows **real Chart.js PNG charts** (baseline vs current cursor mean vs depth), one per dialect in a **2×2** grid.
- Charts are rendered with **Chart.js + `@napi-rs/canvas`** into `bench/results/charts/*.png`.
- CI publishes those PNGs to `bench-charts/pr-<N>` and rewrites the comment to `raw.githubusercontent.com` image URLs (sticky comments cannot load relative paths).
- **Sequential-walk** remains a compact numbers table (single point, not a depth series).
- **CI-gating** table only appears when the gate fires (no noisy/weak dump).

## Comment shape

```markdown
# Benchmark comparison
**✅ no CI-gating regressions** · …

### Deep-page
| ![mssql] | ![mysql] |
| ![postgres] | ![sqlite] |

| Dialect | Depth | Base | Curr | Δ | vs offset |
| … |

### Sequential-walk
| Dialect | Label | Base | Curr | Δ | vs offset |
| … |
```

## Test plan

- [x] Unit tests: PNG signature + image grid markdown (`test/bench-chart.test.ts`)
- [x] Local Chart.js + `@napi-rs/canvas` smoke render
- [ ] CI sticky comment: 2×2 PNG grid loads for all four dialects
- [ ] Charts branch `bench-charts/pr-<N>` updated on each PR run