### PR TITLE
docs: trim agent-style residue from docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,31 +15,21 @@ Cursor‑based (keyset) pagination utilities for [Kysely](https://github.com/kys
 
 ## Table of contents
 
-- [Kysely Cursor](#kysely-cursor)
-  - [Table of contents](#table-of-contents)
-  - [Why keyset pagination?](#why-keyset-pagination)
-  - [Features](#features)
-  - [Install](#install)
-  - [Quick start](#quick-start)
-    - [Warning: this project is in early development, so does not support cross-version token compatiablity](#warning-this-project-is-in-early-development-so-does-not-support-cross-version-token-compatiablity)
-  - [Concepts](#concepts)
-    - [Sorts](#sorts)
-    - [Dialects](#dialects)
-    - [Codecs](#codecs)
-    - [Null Sorting Behavior](#null-sorting-behavior)
-      - [Current behavior](#current-behavior)
-  - [API](#api)
-    - [`createPaginator`](#createpaginator)
-    - [`paginate` (low-level)](#paginate-low-level)
-    - [`paginateWithEdges` (low-level)](#paginatewithedges-low-level)
-  - [Examples](#examples)
-    - [Forward/back pagination](#forwardback-pagination)
-    - [Offset fallback](#offset-fallback)
-    - [Custom codec pipelines](#custom-codec-pipelines)
-  - [Benchmarks](#benchmarks)
-  - [Error Handling](#error-handling)
-  - [FAQ](#faq)
-    - [Acknowledgements](#acknowledgements)
+- [Why keyset pagination?](#why-keyset-pagination)
+- [Features](#features)
+- [Install](#install)
+- [Quick start](#quick-start)
+- [Concepts](#concepts)
+  - [Sorts](#sorts)
+  - [Dialects](#dialects)
+  - [Codecs](#codecs)
+  - [Null ordering](#null-ordering)
+- [API](#api)
+- [Examples](#examples)
+- [Benchmarks](#benchmarks)
+- [Error Handling](#error-handling)
+- [FAQ](#faq)
+- [Acknowledgements](#acknowledgements)
 
 ---
 
@@ -92,7 +82,7 @@ yarn add kysely-cursor
 
 ## Quick start
 
-### Warning: this project is in early development, so does not support cross-version token compatiablity
+> **Warning:** This project is in early development and does not support cross-version token compatibility.
 
 ```ts
 import { Kysely } from 'kysely'
@@ -194,10 +184,9 @@ Provided:
 
 The default cursor codec is `codecPipe(superJsonCodec, base64UrlCodec)`.
 
-### Null Sorting Behavior
+### Null ordering
 
-Handling of `NULL` values during sorting differs between database engines.
-To ensure consistent pagination behavior across dialects, this library now supports **explicit** null ordering on each sort key (`nulls: 'first' | 'last'`) and falls back to dialect-aware defaults when it’s not provided.
+NULL placement differs between engines. Set `nulls: 'first' | 'last'` on a sort key when you need an explicit order; omit it to use the dialect default.
 
 | Database System                  | Default NULLs (ASC) | Default NULLs (DESC) | Supports `NULLS FIRST / LAST`? |
 | -------------------------------- | ------------------- | -------------------- | ------------------------------ |
@@ -206,25 +195,13 @@ To ensure consistent pagination behavior across dialects, this library now suppo
 | **Microsoft SQL Server (MSSQL)** | NULLs **first**     | NULLs **last**       | ❌ Not supported               |
 | **SQLite**                       | NULLs **first**     | NULLs **last**       | ✅ Supported since 3.30.0      |
 
-#### Current behavior
-
-1. **You can set it yourself**
-   On sorts where the column can be nullable, add:
-
 ```ts
 const sort = { col: 'posts.published_at', dir: 'asc', nulls: 'last' }
 ```
 
-If the dialect supports `NULLS FIRST / LAST` (Postgres, SQLite ≥ 3.30.0), this will be emitted as part of the `ORDER BY`. If it **doesn’t** (MySQL, MSSQL), the library throws a `PaginationError` with `code: 'INVALID_SORT'`, so you don’t silently get inconsistent pagination.
+On dialects that support `NULLS FIRST / LAST` (Postgres, SQLite ≥ 3.30.0), this is emitted in the `ORDER BY`. On MySQL and MSSQL, providing `nulls` throws a `PaginationError` with `code: 'INVALID_SORT'` so you don’t silently get inconsistent pagination.
 
-2. **If you don’t set it, the dialect decides**
-   Each dialect declares:
-   - whether it supports explicit null directives
-   - what its default “ascending NULL placement” is
-
-   The paginator then:
-   - uses that default when `dir === 'asc'`
-   - uses the **inverted** default when `dir === 'desc'` (so if ASC puts NULLs first, DESC will put them last)
+When `nulls` is omitted, the dialect’s ascending default is used for `dir: 'asc'`, and the inverted default for `dir: 'desc'`.
 
 ---
 
@@ -389,8 +366,7 @@ const cursorCodec = stashCodec(stash)
 
 ## Benchmarks
 
-Multi-dialect cursor vs offset suite lives in [`bench/`](./bench) (Testcontainers for Postgres / MySQL / MSSQL; local
-SQLite).
+Cursor vs offset benchmarks for every dialect live in [`bench/`](./bench).
 
 ```bash
 pnpm bench:quick          # smoke
@@ -400,10 +376,7 @@ pnpm bench:compare        # vs committed bench/baseline/
 pnpm bench:update-baseline
 ```
 
-CI runs each dialect in parallel on the **lean** profile (deep-page + sequential-walk only), posts a
-sticky PR comparison comment, and fails on CI-gating cursor-mean regressions (≥ 1.5× **and** ≥ dialect
-abs ms floor). Successful pushes to `main` refresh `bench/baseline/` only when every dialect job is
-green (`[skip ci]` bot commit). Failed / regressed main runs do not overwrite the baseline.
+See [`bench/README.md`](./bench/README.md) for methodology, CI regression gating, and how to interpret results.
 
 ---
 
@@ -459,6 +432,6 @@ const paginator = createPaginator({
 
 ---
 
-### Acknowledgements
+## Acknowledgements
 
 Built on the excellent [Kysely](https://github.com/kysely-org/kysely).

--- a/bench/README.md
+++ b/bench/README.md
@@ -22,7 +22,7 @@ await paginator.paginate({ query, sorts, limit, cursor: { offset } })
 
 ## Prerequisites
 
-- Node 18+
+- Node 24+
 - pnpm
 - Docker (for postgres / mysql / mssql)
 
@@ -46,7 +46,7 @@ pnpm bench:quick
 pnpm bench:sqlite
 pnpm bench:postgres
 
-# full poster matrix (all scenarios, dense depths)
+# all scenarios, denser depths
 pnpm bench -- --full
 
 # even heavier local run
@@ -57,11 +57,9 @@ pnpm --filter kysely-cursor-bench bench -- \
 pnpm --filter kysely-cursor-bench bench -- --dialect postgres,sqlite --scenarios all --depths 0,10,100,500
 ```
 
-**Default profile** is what CI runs: only the high-SNR scenarios that feed the regression
-gate (`deep-page`, `sequential-walk`), depths `0,100,500`, walk 25, iters 4/1. Secondary
-scenarios (filtered-feed, author-timeline, scoreboard, ideal-baseline) stay available via
-`--full` or `--scenarios …` but are skipped on PRs to keep wall time near ~30s per dialect
-(MSSQL is often higher solely due to container startup).
+**Default profile** (what CI runs): `deep-page` + `sequential-walk`, depths `0,100,500`, walk 25,
+iters 4/1. Other scenarios are available via `--full` or `--scenarios …`. PRs skip them to keep wall
+time near ~30s per dialect (MSSQL is often higher due to container startup).
 
 ### CLI flags
 
@@ -77,20 +75,20 @@ scenarios (filtered-feed, author-timeline, scoreboard, ideal-baseline) stay avai
 | `--warmup`          | `1` (full: `2`)                                               | Untimed warmup iterations                      |
 | `--out`             | `./bench/results`                                             | Ephemeral report output directory              |
 | `--quick`           | off                                                           | Smoke: smaller seed / fewer iters              |
-| `--full`            | off                                                           | All scenarios + dense depths (poster matrix)   |
+| `--full`            | off                                                           | All scenarios + denser depths                  |
 | `--compare`         | off                                                           | Diff vs committed baseline after the run       |
 | `--update-baseline` | off                                                           | Write `bench/baseline/` (committed snapshot)   |
 
 ## Scenarios
 
-| Scenario            | CI default | What it models                                                   | Why it matters                                                     |
-| ------------------- | :--------: | ---------------------------------------------------------------- | ------------------------------------------------------------------ |
-| **deep-page**       |     ✅     | Library page at depth N (`cursor: { nextPage }` vs `{ offset }`) | Primary library comparison; tokens pre-resolved outside the timer  |
-| **sequential-walk** |     ✅     | Infinite scroll / crawl of N consecutive pages                   | End-to-end chained cost                                            |
-| **filtered-feed**   |  `--full`  | `WHERE status = 'published'` product listing                     | Selective filter + composite index                                 |
-| **author-timeline** |  `--full`  | `WHERE author_id = ?` profile feed                               | Selective secondary key + deep paging                              |
-| **scoreboard**      |  `--full`  | `ORDER BY score DESC, id DESC` ranking                           | Non-time secondary sort + `(score, id)` index                      |
-| **ideal-baseline**  |  `--full`  | Raw keyset SQL matching the dialect’s library emission           | Codec/wrapper ceiling — not a generic “textbook” shape on every DB |
+| Scenario            | CI default | What it models                                                   | Why it matters                                                    |
+| ------------------- | :--------: | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| **deep-page**       |     ✅     | Library page at depth N (`cursor: { nextPage }` vs `{ offset }`) | Primary library comparison; tokens pre-resolved outside the timer |
+| **sequential-walk** |     ✅     | Infinite scroll / crawl of N consecutive pages                   | End-to-end chained cost                                           |
+| **filtered-feed**   |  `--full`  | `WHERE status = 'published'` product listing                     | Selective filter + composite index                                |
+| **author-timeline** |  `--full`  | `WHERE author_id = ?` profile feed                               | Selective secondary key + deep paging                             |
+| **scoreboard**      |  `--full`  | `ORDER BY score DESC, id DESC` ranking                           | Non-time secondary sort + `(score, id)` index                     |
+| **ideal-baseline**  |  `--full`  | Raw keyset SQL matching the dialect’s library emission           | Isolates codec / wrapper overhead vs raw SQL                      |
 
 ### What SQL the library emits (timed scenarios)
 
@@ -120,7 +118,7 @@ WHERE (created_at, id) < ($1, $2)
 
 ### Interpreting library vs ideal
 
-**ideal-baseline** uses raw SQL in the **same form the library uses on that dialect**,
+**ideal-baseline** runs raw SQL in the **same form the library uses on that dialect**,
 without the token codec or paginator wrapper:
 
 | Dialect    | Ideal keyset form              |
@@ -130,9 +128,8 @@ without the token codec or paginator wrapper:
 | `mysql`    | Null-safe OR (not row compare) |
 | `mssql`    | Plain OR                       |
 
-Library deep-page should **approach** ideal on that dialect. A large inverted gap
-(lib ≫ ideal or ideal ≫ lib) usually means plan mismatch, not “magic” library
-performance.
+Library deep-page should approach ideal on that dialect. A large gap usually means a
+plan mismatch between the two paths.
 
 Typical Postgres plans at depth ~1000+ (warm cache, ~800B rows):
 
@@ -140,29 +137,24 @@ Typical Postgres plans at depth ~1000+ (warm cache, ~800B rows):
 | ------------------------------ | --------------------------------- | -------------- | ------------------------------ |
 | Library null-safe OR (default) | Index Scan + Filter, many removed | ~thousands     | ~same as OFFSET                |
 | Library `nullable: false`      | Index Cond seek                   | ~single digits | **much faster**                |
-| Ideal row comparison (raw SQL) | Index Cond seek                   | ~same as seek  | codec ceiling                  |
+| Ideal row comparison (raw SQL) | Index Cond seek                   | ~same as seek  | lower bound without codec      |
 | OFFSET deep skip               | Index Scan, skip N                | ~thousands     | baseline                       |
 
 Postgres runs attach `EXPLAIN (ANALYZE, BUFFERS)` at the deepest measured page
 (library seek form, default null-safe OR, and OFFSET).
 
-### Reading MySQL (and OFFSET cliffs)
+### Reading MySQL
 
-MySQL often shows a **sharp OFFSET cliff** once skip distance and fat row payloads
-add up (this bench selects a non-indexed ~800B `body` column). Cursor stays roughly
-flat while OFFSET can jump from a few ms to hundreds of ms between mid and deep
-pages. That is **engine + workload** behavior (large `OFFSET` still walks and
-discards rows), not a library bug.
-
-**Do not** treat multi-thousand× MySQL speedups as portable marketing numbers —
-they depend on row width, indexes, and depth. Prefer quoting Postgres growth
-curves + plans, and describing MySQL as “cursor flat / OFFSET collapses under
-deep skip.”
+MySQL often shows a sharp OFFSET cliff once skip distance and fat row payloads add up
+(this bench selects a non-indexed ~800B `body` column). Cursor stays roughly flat while
+OFFSET can jump from a few ms to hundreds of ms between mid and deep pages — engine
+behavior for large `OFFSET`, not a library issue. Speedups are workload-dependent
+(row width, indexes, depth); Postgres growth curves are more portable across machines.
 
 ### Stability vs latency
 
-**Cursor pagination still wins on stability** under concurrent inserts/deletes
-(no skipped/duplicated rows). These benches measure **latency**, not correctness.
+Keyset pagination stays stable under concurrent inserts/deletes (no skipped or
+duplicated rows). These benches measure **latency**, not correctness.
 
 ### Dataset
 

--- a/bench/src/config.ts
+++ b/bench/src/config.ts
@@ -19,11 +19,6 @@ export const ALL_SCENARIOS: ScenarioId[] = [
   'ideal-baseline',
 ]
 
-/**
- * Default / CI profile: high-SNR cells only.
- * Matches the CI gate (deep-page + sequential-walk) and keeps PR wall time ~30s
- * where the engine allows (MSSQL container start still dominates that dialect).
- */
 export const CI_SCENARIOS: ScenarioId[] = ['deep-page', 'sequential-walk']
 
 export type BenchConfig = {
@@ -48,7 +43,7 @@ export type BenchConfig = {
   resultsDir: string
   /** Skip container dialects that require Docker. */
   quick: boolean
-  /** Full poster matrix (all scenarios, denser depths). */
+  /** All scenarios with denser depths. */
   full: boolean
 }
 

--- a/bench/src/gate.ts
+++ b/bench/src/gate.ts
@@ -28,9 +28,8 @@ export const MIN_ABS_MS: Record<DialectName, number> = {
 }
 
 /**
- * High-SNR scenarios only. Secondary sweeps (scoreboard, filtered-feed,
- * author-timeline) stay in the report but do not fail CI — their walks/depths
- * are noisier on GHA and rarely the first signal of a real library regression.
+ * Scenarios that can fail CI. Others (scoreboard, filtered-feed, author-timeline,
+ * ideal-baseline) stay informational — noisier on GHA and secondary signals.
  */
 export const GATING_SCENARIOS = new Set(['deep-page', 'sequential-walk'])
 

--- a/bench/src/index.ts
+++ b/bench/src/index.ts
@@ -37,7 +37,7 @@ Run options:
   --warmup <n>               warmup iterations
   --out <dir>                ephemeral results directory        (default: ./bench/results)
   --quick                    smoke: smaller seed / fewer iters
-  --full                     poster matrix: all scenarios, dense depths
+  --full                     all scenarios, denser depths
   --update-baseline          write slim results to bench/baseline/ (skipped if compare failed)
   --baseline-dir <dir>       baseline directory                 (default: ./bench/baseline)
   --git-sha <sha>            record SHA into baseline JSON

--- a/bench/src/scenarios/ideal-baseline.ts
+++ b/bench/src/scenarios/ideal-baseline.ts
@@ -7,23 +7,14 @@ import { measure, samplesFor, summarize } from '../metrics.js'
 import type { BenchDB, ComparisonRow, Post, Sample, ScenarioContext, ScenarioResult } from '../types.js'
 
 /**
- * Raw SQL keyset form that matches what the library emits for feed sorts with
- * `nullable: false` on each dialect (see MysqlPaginationDialect /
- * PostgresPaginationDialect meta flags). Not a generic “textbook” shape.
+ * Raw SQL keyset matching library emission for feed sorts with `nullable: false`.
  *
- * | Dialect  | Library path (`nullable: false`) | Ideal baseline SQL        |
+ * | Dialect  | Library path                     | Ideal baseline SQL        |
  * |----------|----------------------------------|---------------------------|
  * | postgres | row_compare                      | `(created_at, id) < (?,?)`|
  * | sqlite   | row_compare                      | same                      |
- * | mysql    | null_safe_or (intentional)       | IS NOT NULL guards + OR   |
+ * | mysql    | null_safe_or                     | IS NOT NULL guards + OR   |
  * | mssql    | plain_or                         | classic OR, no null guards|
- *
- * MySQL keeps null-safe OR even when callers mark keys non-null: benches show
- * plain OR / row compare often regress at depth on that engine. Ideal must
- * use the same form or “library vs ceiling” charts invert (lib faster than
- * “ideal” row compare).
- *
- * Compare with library deep-page to isolate token codec + wrapper overhead.
  */
 export type IdealKeysetForm = 'row_compare' | 'null_safe_or' | 'plain_or'
 
@@ -76,21 +67,18 @@ const describeForm = (form: IdealKeysetForm): string => {
   switch (form) {
     case 'row_compare':
       return (
-        'Dialect-matched raw keyset via row comparison `(created_at, id) < ($1, $2)` vs OFFSET — ' +
-        'same shape as library deep-page with `nullable: false` on this dialect (no token codec). ' +
-        'On Postgres this is an Index Cond seek. Compare with deep-page for codec/wrapper overhead.'
+        'Raw keyset via row comparison `(created_at, id) < ($1, $2)` vs OFFSET — ' +
+        'same shape as library deep-page with `nullable: false` (no token codec).'
       )
     case 'null_safe_or':
       return (
-        'Dialect-matched raw keyset via null-safe OR (MySQL library path even with `nullable: false`) ' +
-        'vs OFFSET — no library wrappers or token codec. Row compare / plain OR are *not* used as ' +
-        'the ceiling here; MySQL often seeks this form better at depth.'
+        'Raw keyset via null-safe OR (MySQL library path even with `nullable: false`) ' +
+        'vs OFFSET — no library wrappers or token codec.'
       )
     case 'plain_or':
       return (
-        'Dialect-matched raw keyset via classic OR (`created_at < $1 OR (created_at = $1 AND id < $2)`) ' +
-        'vs OFFSET — same shape as library deep-page on MSSQL (no row-value compare, no null-safe ' +
-        'wrappers, no token codec).'
+        'Raw keyset via classic OR (`created_at < $1 OR (created_at = $1 AND id < $2)`) ' +
+        'vs OFFSET — same shape as library deep-page on MSSQL (no token codec).'
       )
   }
 }

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -2,17 +2,6 @@
 
 A small, runnable tour of [kysely-cursor](../..) against Postgres. It seeds a `posts` table and walks through the library’s main APIs the way you’d use them in an app.
 
-## Database lifecycle (Compose, not Testcontainers)
-
-This example uses **Docker Compose + pnpm scripts**, not Testcontainers.
-
-| Approach                            | Good for                                                                                          |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Compose + scripts** (what we use) | Learning / iterating: DB stays up, reconnect with `psql`, re-run demos in ~1s, no extra Node deps |
-| **Testcontainers**                  | Automated tests in CI (this repo’s `test/dialect/*.test.ts`) — isolated, ephemeral, parallel      |
-
-The demo code never starts Docker itself; `package.json` owns that boundary so `index.ts` stays about the library.
-
 ## Prerequisites
 
 - Node.js 24+
@@ -21,7 +10,7 @@ The demo code never starts Docker itself; `package.json` owns that boundary so `
 
 ## Run
 
-From the **repo root** (starts Compose Postgres, then demos):
+From the **repo root** (starts Postgres, then demos):
 
 ```bash
 pnpm example:postgres
@@ -30,7 +19,7 @@ pnpm example:postgres
 From this directory:
 
 ```bash
-pnpm start          # db:up + demos (preferred)
+pnpm start          # start Postgres + run demos
 pnpm db:up          # start Postgres only (stays up for iteration)
 pnpm dev            # demos only (expects DB already up)
 pnpm db:down        # stop / remove the container
@@ -51,7 +40,7 @@ PAGINATION_SECRET='dev-only-secret' pnpm start
 ```
 
 ```bash
-# Bring-your-own database (skips needing Compose if you only run `pnpm dev`)
+# Bring-your-own database (skips Compose if you only run `pnpm dev`)
 DATABASE_URL=postgres://user:pass@localhost:5432/mydb pnpm dev
 ```
 
@@ -66,35 +55,16 @@ DATABASE_URL=postgres://user:pass@localhost:5432/mydb pnpm dev
 | 5   | Numeric offset            | `cursor: { offset }`                            |
 | 6   | Full result walk          | Loop on `nextPage` until exhausted              |
 
-Also covered in the supporting modules:
-
-- **`nullable: false`** on non-null feed keys so Postgres can use row-value compare seeks
-- **Composite indexes** that match sort shapes
-- **Pluggable codecs** — default SuperJSON → Base64URL, optional AES-GCM via `PAGINATION_SECRET`
-- **`keysetStrategy: 'auto'`** (row compare when allowed)
-
-## Layout
+Supporting modules also show composite indexes matched to sort shapes, `nullable: false` for Postgres row-value seeks, pluggable codecs, and `keysetStrategy: 'auto'`.
 
 ```
 examples/postgres/
-  docker-compose.yml   Example Postgres (port 54329)
+  docker-compose.yml   Postgres on port 54329
   package.json         db:up / db:down / start / dev
-  index.ts             Entry: connect → migrate → seed → demos
-  db.ts                Schema, indexes, deterministic seed
+  index.ts             connect → migrate → seed → demos
+  db.ts                schema, indexes, seed
   paginator.ts         createPaginator + codec pipelines
-  demos.ts             One function per feature
-  README.md            This file
+  demos.ts             one function per feature
 ```
 
-Copy patterns from `paginator.ts` and `demos.ts` into your app; Compose scripts are just harness.
-
-## Key takeaways
-
-1. **Sorts must uniquely identify rows** — end with a non-null unique key (usually primary key).
-2. **Reuse one paginator** — dialect, codec, and keyset strategy are app-level; only query / sorts / cursor change per request.
-3. **Match indexes to sorts** — e.g. `(created_at DESC, id DESC)` for the feed.
-4. **Mark non-null leading keys** with `nullable: false` when you want seek-friendly SQL on Postgres.
-5. **Keep the same `sorts` array** when following `nextPage` / `prevPage` (tokens include a sort signature).
-6. Prefer keyset over **offset** for deep pages; use offset only for legacy page numbers or shallow admin UIs.
-
-For full API docs, see the [root README](../../README.md).
+For full API docs and pagination tips, see the [root README](../../README.md).

--- a/examples/postgres/db.ts
+++ b/examples/postgres/db.ts
@@ -1,12 +1,7 @@
 import { type Generated, Kysely, PostgresDialect, sql } from 'kysely'
 import { Pool } from 'pg'
 
-/**
- * Tiny blog schema used by the demos.
- *
- * Indexes match the common keyset sort shapes so Postgres can seek instead of
- * scanning — the same composite indexes you want in production.
- */
+/** Tiny blog schema used by the demos. Indexes match the keyset sort shapes. */
 export type Post = {
   id: Generated<number>
   title: string
@@ -52,32 +47,28 @@ export async function migrate(db: Kysely<Database>): Promise<void> {
     .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
     .execute()
 
-  // Feed: (created_at DESC, id DESC) — matches nullable:false seek path on Postgres.
   await sql`
     create index if not exists posts_created_at_id_desc
     on posts (created_at desc, id desc)
   `.execute(db)
 
-  // Author timeline: equality on author + same keyset tail.
   await sql`
     create index if not exists posts_author_created_at_id_desc
     on posts (author, created_at desc, id desc)
   `.execute(db)
 
-  // Scoreboard.
   await sql`
     create index if not exists posts_score_id_desc
     on posts (score desc, id desc)
   `.execute(db)
 
-  // Published feed with drafts (null published_at) ordered last.
   await sql`
     create index if not exists posts_published_at_id_desc
     on posts (published_at desc nulls last, id desc)
   `.execute(db)
 }
 
-/** Deterministic seed so re-runs are stable and demos print the same shape. */
+/** Deterministic seed so re-runs print the same shape. */
 export async function seed(db: Kysely<Database>, count = 24): Promise<void> {
   const existing = await db
     .selectFrom('posts')
@@ -96,7 +87,6 @@ export async function seed(db: Kysely<Database>, count = 24): Promise<void> {
       title: `Post ${String(n).padStart(2, '0')}`,
       author: AUTHORS[i % AUTHORS.length]!,
       score: (n * 17) % 100,
-      // Every 5th post is a draft (null published_at).
       published_at: isDraft ? null : new Date(base + i * 3_600_000),
       created_at: new Date(base + i * 3_600_000),
     }
@@ -105,7 +95,6 @@ export async function seed(db: Kysely<Database>, count = 24): Promise<void> {
   await db.insertInto('posts').values(rows).execute()
 }
 
-/** Kysely owns the pool lifecycle when the dialect was given that pool. */
 export async function destroy(db: Kysely<Database>): Promise<void> {
   await db.destroy()
 }

--- a/examples/postgres/demos.ts
+++ b/examples/postgres/demos.ts
@@ -5,16 +5,14 @@ import type { Database, PostRow } from './db.js'
 
 const PAGE_SIZE = 5
 
-/** Chronological feed — non-null keys unlock Postgres row-compare seeks. */
+/** Chronological feed (`nullable: false` enables Postgres row-value compare). */
 export const feedSorts = [
   {
     col: 'posts.created_at' as const,
     dir: 'desc' as const,
     output: 'created_at' as const,
-    /** Assert no NULLs so the dialect may emit `(created_at, id) < ($1, $2)`. */
     nullable: false as const,
   },
-  // Final sort must be unique + non-nullable (tie-breaker). Prefer a primary key.
   { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
 ] as const
 
@@ -29,10 +27,7 @@ export const scoreSorts = [
   { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
 ] as const
 
-/**
- * Nullable `published_at` with explicit NULLS LAST (Postgres supports the directive).
- * Do **not** set `nullable: false` here — drafts are NULL and need the null-safe path.
- */
+/** Nullable `published_at` with `nulls: 'last'` (drafts sort after published posts). */
 export const publishedSorts = [
   {
     col: 'posts.published_at' as const,
@@ -91,10 +86,7 @@ function heading(title: string, blurb: string) {
 
 /** Demo 1 — first page, next page, then walk back with prevPage. */
 export async function demoForwardAndBack(db: Kysely<Database>, paginator: Paginator) {
-  heading(
-    '1. Forward / back keyset pagination',
-    'Tokens are opaque; sorts must stay identical between requests (signature check).',
-  )
+  heading('1. Forward / back keyset pagination', 'nextPage forward, prevPage back (same sorts each request).')
 
   const query = postsQuery(db)
 
@@ -133,7 +125,7 @@ export async function demoForwardAndBack(db: Kysely<Database>, paginator: Pagina
     cursor: { prevPage: page2.prevPage },
   })
 
-  console.log('\nBack to page 1 (via prevPage — library inverts sorts internally):')
+  console.log('\nBack to page 1 (via prevPage):')
   printRows(back.items)
   printPageMeta(back)
 
@@ -143,10 +135,7 @@ export async function demoForwardAndBack(db: Kysely<Database>, paginator: Pagina
 
 /** Demo 2 — same paginator + sorts, different filtered query (author timeline). */
 export async function demoFilteredFeed(db: Kysely<Database>, paginator: Paginator) {
-  heading(
-    '2. Filtered feed (author timeline)',
-    'Keyset works with WHERE filters — keep an index that starts with the filter columns.',
-  )
+  heading('2. Filtered feed (author timeline)', 'Same sorts, different WHERE (author = ada).')
 
   const author = 'ada'
   const query = postsQuery(db).where('author', '=', author)
@@ -164,10 +153,7 @@ export async function demoFilteredFeed(db: Kysely<Database>, paginator: Paginato
 
 /** Demo 3 — nullable sort key + explicit nulls: 'last' (Postgres NULLS LAST). */
 export async function demoNullablePublishedAt(db: Kysely<Database>, paginator: Paginator) {
-  heading(
-    "3. Nullable sort + nulls: 'last'",
-    'Drafts (published_at IS NULL) sort after published posts. Uses null-safe keyset SQL.',
-  )
+  heading("3. Nullable sort + nulls: 'last'", 'Drafts (published_at IS NULL) sort after published posts.')
 
   const page = await paginator.paginate({
     query: postsQuery(db),
@@ -203,15 +189,14 @@ export async function demoWithEdges(db: Kysely<Database>, paginator: Paginator) 
   printPageMeta(result)
 }
 
-/** Demo 5 — numeric offset when you must (legacy UI page numbers). Prefer keyset. */
+/** Demo 5 — numeric offset fallback. */
 export async function demoOffsetFallback(db: Kysely<Database>, paginator: Paginator) {
-  heading('5. Offset fallback', 'cursor: { offset } skips N rows. Fine for small N / admin tools; avoid deep pages.')
+  heading('5. Offset fallback', 'cursor: { offset } skips N rows. Prefer keyset for deep pages.')
 
   const page = await paginator.paginate({
     query: postsQuery(db),
     sorts: feedSorts,
     limit: PAGE_SIZE,
-    // Skip first page (5 rows) → roughly “page 2” of a 1-based UI.
     cursor: { offset: PAGE_SIZE },
   })
 
@@ -220,15 +205,9 @@ export async function demoOffsetFallback(db: Kysely<Database>, paginator: Pagina
   printPageMeta(page)
 }
 
-/**
- * Demo 6 — walk the whole feed with nextPage until exhausted.
- * Useful pattern for exports / background jobs.
- */
+/** Demo 6 — walk the whole feed with nextPage until exhausted. */
 export async function demoWalkAll(db: Kysely<Database>, paginator: Paginator) {
-  heading(
-    '6. Walk entire result set',
-    'Loop on nextPage until hasNextPage is false — stable under concurrent inserts at the head.',
-  )
+  heading('6. Walk entire result set', 'Loop on nextPage until hasNextPage is false.')
 
   const query = postsQuery(db)
   let cursor: { nextPage: string } | undefined

--- a/examples/postgres/docker-compose.yml
+++ b/examples/postgres/docker-compose.yml
@@ -1,5 +1,4 @@
-# Local Postgres for the kysely-cursor example.
-# Managed via package.json: pnpm db:up | db:down | start
+# Local Postgres for the kysely-cursor example (pnpm db:up | db:down | start).
 name: kysely-cursor-example-postgres
 
 services:
@@ -10,7 +9,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: kysely_cursor_example
     ports:
-      # Dedicated host port so we don't fight a system Postgres on 5432.
+      # Host 54329 avoids clashing with a system Postgres on 5432.
       - '54329:5432'
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres -d kysely_cursor_example']

--- a/examples/postgres/index.ts
+++ b/examples/postgres/index.ts
@@ -9,13 +9,11 @@
  *   5. Offset fallback
  *   6. Walking an entire result set
  *
- * Database lifecycle is owned by package scripts (Docker Compose), not this file:
- *   pnpm start     # db:up + run demos (preferred)
+ * Scripts (from this directory, or `pnpm example:postgres` from repo root):
+ *   pnpm start     # start Postgres + run demos
  *   pnpm db:up     # start Postgres only
  *   pnpm db:down   # stop Postgres
  *   pnpm dev       # demos only (DB must already be up, or set DATABASE_URL)
- *
- * From repo root: pnpm example:postgres
  */
 
 import { createDb, destroy, migrate, seed } from './db.js'

--- a/examples/postgres/paginator.ts
+++ b/examples/postgres/paginator.ts
@@ -8,34 +8,16 @@ import {
   type Paginator,
 } from 'kysely-cursor'
 
-/**
- * Default opaque tokens: SuperJSON (Dates, BigInts, …) → Base64 URL-safe string.
- * This is also the library default when you omit `cursorCodec`.
- */
+/** SuperJSON → Base64 URL-safe (library default when `cursorCodec` is omitted). */
 export const defaultCursorCodec = codecPipe(superJsonCodec, base64UrlCodec)
 
-/**
- * Production-style tokens: SuperJSON → AES-GCM → Base64 URL.
- * Set `PAGINATION_SECRET` to try the encrypted demo path.
- */
+/** SuperJSON → AES-GCM → Base64 URL. Used when `PAGINATION_SECRET` is set. */
 export function createEncryptedCursorCodec(secret: string) {
   return codecPipe(superJsonCodec, createAesCodec(secret), base64UrlCodec)
 }
 
-/**
- * One paginator per app (or per token policy). Reuse it for every page request —
- * dialect + codec + keyset strategy stay fixed; only the query / sorts / cursor change.
- */
-export function createAppPaginator(options?: {
-  /** Prefer encrypted tokens when a secret is available. */
-  secret?: string
-  /**
-   * `auto` (default) uses Postgres row-value compare `(a, b) < ($1, $2)` when
-   * every non-final sort is `nullable: false` and directions are uniform.
-   * Use `portable` to force plain multi-column OR instead.
-   */
-  keysetStrategy?: 'auto' | 'portable'
-}): Paginator {
+/** Shared paginator for the demos. */
+export function createAppPaginator(options?: { secret?: string; keysetStrategy?: 'auto' | 'portable' }): Paginator {
   const cursorCodec = options?.secret ? createEncryptedCursorCodec(options.secret) : defaultCursorCodec
 
   return createPaginator({

--- a/src/codec/codec.ts
+++ b/src/codec/codec.ts
@@ -1,15 +1,4 @@
-/**
- * A bidirectional transformer between two value types: input `I` and output `O`.
- *
- * @template I The type accepted by `encode` and produced by `decode`.
- * @template O The type produced by `encode` and accepted by `decode`.
- *
- * @property {(value: I) => Promise<O> | O} encode
- * Transform an input value `I` into an output value `O`. May be sync or async.
- *
- * @property {(value: O) => Promise<I> | I} decode
- * Inverse transform: turn an output value `O` back into an input value `I`. May be sync or async.
- */
+/** Bidirectional transform between input `I` and output `O` (sync or async). */
 export type Codec<I = any, O = any> = {
   encode: (value: I) => Promise<O> | O
   decode: (value: O) => Promise<I> | I
@@ -36,15 +25,8 @@ type Composable<Cs extends readonly Codec[]> = Cs extends readonly []
       : false
 
 /**
- * Compose a non-empty list of codecs into a single codec.
- * Validates that the codecs are type-composable: the input of each codec must be the output of the previous.
- *
- * - `encode` runs **left → right** through the provided codecs.
- * - `decode` runs **right → left** (the inverse order).
- *
- * @template Cs A non-empty readonly tuple of codecs to compose.
- * @param {...Cs} codecs The codecs to compose, in the order their `encode` functions should run.
- * @returns Codec<InOf<First<Cs>>, OutOf<Last<Cs>>> A codec representing the composition, or `never` if the codecs are not type-composable.
+ * Compose codecs left-to-right for encode (right-to-left for decode).
+ * Type-checks that each codec’s input matches the previous codec’s output.
  */
 export const codecPipe = <Cs extends readonly [Codec, ...Codec[]]>(...codecs: Cs) =>
   ({

--- a/src/codec/encrypt.ts
+++ b/src/codec/encrypt.ts
@@ -3,25 +3,16 @@ import crypto from 'crypto'
 import type { Codec } from './codec.js'
 
 /**
- * AES-256-GCM string codec using scrypt-derived keys.
+ * AES-256-GCM string codec (scrypt-derived key, random salt/IV, versioned payload).
  *
- * ## Usage
  * ```ts
- * const codec = createAesCodec(process.env.SECRET!);
- *
- * const encrypted = await codec.encode("hello");
- * const decrypted = await codec.decode(encrypted);
+ * const codec = createAesCodec(process.env.SECRET!)
+ * const encrypted = await codec.encode('hello')
+ * const decrypted = await codec.decode(encrypted)
  * ```
  *
- * ## Notes
- * - Uses `scrypt` (N=2^15, r=8, p=1) to derive a 256-bit key from `secret` + random 16-byte salt.
- * - Encrypts with random 12-byte IV and includes a 16-byte auth tag.
- * - Payload = Base64 of `[1-byte ver][salt][iv][tag][ciphertext]`.
- * - Tampering or wrong secret throws on decode.
- * - Works in Node.js with built-in `crypto`.
- *
- * @param secret - The secret key to use for the codec.
- * @returns The codec.
+ * Payload is Base64 of `[1-byte ver][salt][iv][tag][ciphertext]`.
+ * Tampering or a wrong secret throws on decode.
  */
 export const createAesCodec = (secret: string): Codec<string, string> => {
   const VERSION = Buffer.from([1])

--- a/src/codec/stash.ts
+++ b/src/codec/stash.ts
@@ -2,38 +2,15 @@ import { randomUUID } from 'crypto'
 
 import type { Codec } from './codec.js'
 
-/**
- * A simple asynchronous key-value storage interface.
- *
- * Each key and value must be a string.
- * Implementations could be in-memory, filesystem-based, Redis-backed, etc.
- */
+/** Async string key-value store (in-memory, Redis, filesystem, …). */
 export type Stash = {
-  /**
-   * Retrieve a value by key.
-   * @param key The key to retrieve.
-   * @returns The value.
-   */
   get: (key: string) => Promise<string>
-  /**
-   * Store a value under a specific key.
-   * @param key The key to store the value under.
-   * @param value The value to store.
-   */
   set: (key: string, value: string) => Promise<void>
 }
 
 /**
- * Creates a {@link Codec} that encodes strings into stash keys and decodes keys back into their stored strings.
- *
- * - **encode(value)**: stores the given string `value` in the provided {@link Stash} under a randomly generated UUID key.
- *   Returns the generated key.
- * - **decode(key)**: retrieves and returns the original string value stored under `key`.
- *
- * This is useful for scenarios where you want to replace large or sensitive strings
- * with short unique identifiers and retrieve them later.
- *
- * @param stash The stash instance to use for storage and retrieval.
+ * Codec that stores the payload in external storage and returns a random UUID key.
+ * Useful for short tokens when payloads are large or sensitive.
  */
 export const stashCodec = (stash: Stash): Codec<string, string> => ({
   decode: (value) => stash.get(value),

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -57,8 +57,6 @@ export const decodeCursor = async (cursor: CursorIncoming, keysetCodec: Codec<an
       payload: await decodeCursorPayload(cursor.prevPage, keysetCodec),
     }
   if ('offset' in cursor) {
-    // offset is user input too: a negative/fractional offset would otherwise fall
-    // through to the driver and surface as an UNEXPECTED_ERROR instead of a 400
     if (!Number.isInteger(cursor.offset) || cursor.offset < 0)
       throw new PaginationError({ message: 'Invalid pagination offset', code: 'INVALID_TOKEN' })
     return { type: 'offset', offset: cursor.offset }
@@ -77,8 +75,6 @@ const decodeCursorPayload = async (token: string, keysetCodec: Codec<any, string
 
   const parsed = CursorPayloadSchema.safeParse(decoded)
   if (!parsed.success) {
-    // a numeric but mismatched version means the token was minted by an incompatible
-    // version of this library — say so explicitly rather than reporting a generic failure
     const version = (decoded as { v?: unknown } | null)?.v
     const message =
       typeof version === 'number' && version !== CURSOR_VERSION
@@ -196,9 +192,7 @@ export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends
   const isLast = idx === sorts.length - 1
   const cmp = dir === 'desc' ? '<' : '>'
 
-  // The final sort is required to be non-nullable & unique, so a NULL value here
-  // means the token is malformed or tampered with. Fail loudly rather than
-  // silently rewinding to the start of the result set.
+  // Final sort is non-nullable; null here means a malformed token.
   if (isLast && value === null)
     throw new PaginationError({
       message: `Pagination cursor has null value for final sort "${key}"`,
@@ -208,46 +202,24 @@ export const buildCursorPredicateRecursive = <DB, TB extends keyof DB, S extends
   // If there are more sort keys, build the recursive predicate for ties.
   const next = !isLast ? buildCursorPredicateRecursive(eb, sorts, decoded, meta, idx + 1) : undefined
 
-  // ──────────────────────────────────────────────────────────────────────────────
-  // Cases where the cursor's current value is NULL
-  // (never the last sort key — rejected above)
-  // ──────────────────────────────────────────────────────────────────────────────
+  // NULL cursor value (never the last sort key — rejected above).
   if (value === null) {
     if (nulls === 'first') {
-      // Order: NULLs block first, then non-NULLs.
-      // After a NULL cursor:
-      //   • Remaining NULLs that come after the cursor within the NULLs block (tie goes to `next`)
-      //   • All non-NULLs (they come after the NULL block)
+      // Remaining NULLs in the leading NULL block (tie → next), then all non-NULLs.
       return eb.or([eb.and([eb(col, 'is', null), next!]), eb(col, 'is not', null)])
     }
-    // nulls === 'last'
-    // Order: non-NULLs first, then NULLs block.
-    // After a NULL cursor inside the trailing NULL block:
-    //   • Only remaining NULLs after this row (tie → `next`). There are no non-NULLs after.
+    // nulls === 'last': only remaining NULLs after this row (tie → next).
     return eb.and([eb(col, 'is', null), next!])
   }
 
-  // ──────────────────────────────────────────────────────────────────────────────
-  // Cursor value is NON-NULL
-  // ──────────────────────────────────────────────────────────────────────────────
-
-  // Base comparisons apply only to non-NULL candidates.
-  // (We add NULL candidates depending on null placement.)
+  // Non-NULL cursor value.
   const nonNullGreater = eb.and([eb(col, 'is not', null), eb(col, cmp, value)])
   const nonNullTieThenNext = !isLast ? eb.and([eb(col, 'is not', null), eb(col, '=', value), next!]) : undefined
 
   if (isLast) {
-    // Last sort key: no recursion available.
-    // After a non-NULL value:
-    //   • non-NULL rows strictly greater (per dir)
-    //   • plus NULLs if and only if NULLs are placed after non-NULLs at this position
+    // Strictly greater non-NULLs; include NULLs only when they sort after non-NULLs.
     return eb.or([nonNullGreater, ...(nulls === 'last' ? [eb(col, 'is', null)] : [])])
   }
 
-  // Not last: include the tie → next, and include NULLs when they are placed after non-NULLs.
-  return eb.or([
-    nonNullGreater, // advance on current column
-    nonNullTieThenNext!, // tie → look at the next column
-    ...(nulls === 'last' ? [eb(col, 'is', null)] : []), // when NULLs are after, they are also "after" the cursor
-  ])
+  return eb.or([nonNullGreater, nonNullTieThenNext!, ...(nulls === 'last' ? [eb(col, 'is', null)] : [])])
 }

--- a/src/keyset.ts
+++ b/src/keyset.ts
@@ -35,21 +35,17 @@ export const classifyKeyset = (sorts: SortSet<any, any, any>, payload: CursorPay
 
     const value = payload.k[key]
 
-    // Final key must be non-null (unique tie-breaker). Fail loudly.
     if (isLast && value === null)
       throw new PaginationError({
         message: `Pagination cursor has null value for final sort "${key}"`,
         code: 'INVALID_TOKEN',
       })
 
-    // Explicit null placement always forces the null-safe path.
     if (sort.nulls === 'first' || sort.nulls === 'last') return { kind: 'null_safe' }
 
-    // Non-final keys default to nullable unless the caller opts out.
     if (!isLast) {
       if (sort.nullable !== false) return { kind: 'null_safe' }
-      // Defensive: a null in the token on a "non-null" leading key falls back
-      // to the null-safe path rather than emitting non-null SQL.
+      // Null on a "non-null" leading key → fall back to null-safe SQL.
       if (value === null) return { kind: 'null_safe' }
     }
   }
@@ -78,12 +74,11 @@ export const selectKeysetStrategy = (
 ): EmitKind => {
   if (class_.kind === 'null_safe') return 'null_safe_or'
 
-  // `portable` never uses row compare; `auto` prefers it when class + dialect allow.
   const allowRow = opt !== 'portable' && meta.supportsRowValueCompare && class_.uniformDir !== 'mixed'
 
   if (allowRow) return 'row_compare'
 
-  // Some engines (MySQL) seek null-safe OR better than classic plain OR at depth.
+  // MySQL seeks null-safe OR better than plain OR at depth.
   if (meta.supportsPlainOrKeyset === false) return 'null_safe_or'
 
   return 'plain_or'

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,8 @@ export type DialectMeta = {
   /** SQL row-value comparison: (a, b) < ($1, $2) */
   supportsRowValueCompare: boolean
   /**
-   * When false, `simple_non_null` sorts stay on the null-safe OR tree instead of
-   * classic plain OR. MySQL's optimizer seeks the null-safe form well but often
-   * walks plain OR / row compare at depth (benches). Defaults to true.
+   * When false, non-null sorts stay on null-safe OR instead of plain OR.
+   * MySQL seeks null-safe OR better at depth. Defaults to true.
    */
   supportsPlainOrKeyset?: boolean
 }


### PR DESCRIPTION
## Summary

- Strip LLM-style over-emphasis from example/root/bench docs (e.g. Compose vs Testcontainers).
- Shorten comments/JSDoc that re-argue design decisions instead of documenting the code.

## Test plan

- [x] `pnpm typecheck`
- [x] Unit tests (`keyset`, `codec`, `pagination`)