### PR TITLE
Rename nullable to notNull; rewrite README

### DIFF
--- a/.changeset/keyset-predicate-optimization.md
+++ b/.changeset/keyset-predicate-optimization.md
@@ -2,4 +2,4 @@
 'kysely-cursor': minor
 ---
 
-Optimize keyset WHERE emission for non-null sorts: optional `nullable: false` on sort items, dialect-aware plain OR / row-value compare, and `keysetStrategy` (`auto` | `portable`). Default (unmarked) leading sorts stay on the null-safe path.
+Optimize keyset WHERE emission for non-null sorts: optional `notNull: true` on sort items, dialect-aware plain OR / row-value compare, and `keysetStrategy` (`auto` | `portable`). Default (unmarked) leading sorts stay on the null-safe path.

--- a/README.md
+++ b/README.md
@@ -1,437 +1,252 @@
-# Kysely Cursor
+# kysely-cursor
 
-[![NPM Version](https://img.shields.io/npm/v/kysely-cursor?style=flat&label=latest)](https://github.com/lukewpc/kysely-cursor/releases/latest)
-[![Tests](https://github.com/lukewpc/kysely-cursor/actions/workflows/ci.yml/badge.svg)](https://github.com/lukewpc/kysely-cursor)
-[![License](https://img.shields.io/github/license/lukewpc/kysely-cursor?style=flat)](https://github.com/lukewpc/kysely-cursor/blob/master/LICENSE)
+[![NPM Version](https://img.shields.io/npm/v/kysely-cursor?style=flat&label=latest)](https://www.npmjs.com/package/kysely-cursor)
+[![Tests](https://github.com/lukewpc/kysely-cursor/actions/workflows/ci.yml/badge.svg)](https://github.com/lukewpc/kysely-cursor/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/lukewpc/kysely-cursor?style=flat)](./LICENSE)
 [![Coverage](https://codecov.io/gh/lukewpc/kysely-cursor/branch/main/graph/badge.svg)](https://codecov.io/gh/lukewpc/kysely-cursor)
 
-Cursor‑based (keyset) pagination utilities for [Kysely](https://github.com/kysely-org/kysely).
+Cursor-based (keyset) pagination for [Kysely](https://github.com/kysely-org/kysely).
 
-- Fast, stable page navigation using keyset predicates
-- Built‑in dialects: PostgreSQL, MySQL, MSSQL, SQLite
-- Pluggable **codecs** for opaque, portable, and optionally encrypted page tokens
-
----
-
-## Table of contents
-
-- [Why keyset pagination?](#why-keyset-pagination)
-- [Features](#features)
-- [Install](#install)
-- [Quick start](#quick-start)
-- [Concepts](#concepts)
-  - [Sorts](#sorts)
-  - [Dialects](#dialects)
-  - [Codecs](#codecs)
-  - [Null ordering](#null-ordering)
-- [API](#api)
-- [Examples](#examples)
-- [Benchmarks](#benchmarks)
-- [Error Handling](#error-handling)
-- [FAQ](#faq)
-- [Acknowledgements](#acknowledgements)
+- Fast, stable next/prev via keyset predicates
+- Dialects: PostgreSQL, MySQL, MSSQL, SQLite
+- Explicit null ordering (`nulls: 'first' | 'last'`) where the engine supports it
+- Pluggable codecs (opaque, encryptable, or stashed tokens)
+- Connection-style edges via `paginateWithEdges`
 
 ---
 
-## Why keyset pagination?
+## Why keyset?
 
-Offset/limit pagination (`OFFSET … LIMIT …`) is simple but can be slow and unstable on large tables: later pages get
-progressively slower; concurrent writes can skip/duplicate rows; offsets leak collection size.
+`OFFSET … LIMIT` is simple but deep pages get slower and concurrent writes can skip/duplicate rows. **Keyset pagination** seeks from the boundary row’s sort keys (e.g. `(created_at, id)`) so the engine can use an index range instead of skipping rows.
 
-**Keyset pagination** derives a cursor from your boundary row’s sort keys (e.g., `(created_at DESC, id DESC)`),
-yielding:
-
-- **Fast** — index range scans instead of large skips
-- **Stable** — resilient to inserts/deletes between requests
-- **Compact** — opaque, portable tokens instead of raw offsets
-
----
-
-## Features
-
-- **Next/previous** page navigation with automatic sort inversion for `prev`.
-- **Offset fallback** via `cursor: { offset: number }` when you must use numeric offsets.
-- **Optional opt-in** for faster deep-page queries when leading sort keys are non-null (`nullable: false`).
-- **Pluggable codecs** for page tokens: SuperJSON, Base64 URL, AES‑GCM encryption, and external stash storage.
-- **Composable codecs** (`codecPipe`) to build pipelines like `superjson → encrypt → base64url`.
-- **Typed** end‑to‑end with Kysely generics; sort keys map to your selected output.
-- **Helpful errors** (`PaginationError`) for bad input and misconfigurations.
-- **Dialect aware null ordering** consistent with engine semantics.
+Offset is still available as `cursor: { offset }` for legacy numeric pages.
 
 ---
 
 ## Install
 
 ```bash
-# pnpm
-pnpm add kysely-cursor
-
-# npm
-npm i kysely-cursor
-
-# yarn
-yarn add kysely-cursor
+pnpm add kysely-cursor   # or: npm i / yarn add
 ```
 
-**Peer requirements**
+Kysely ≥ 0.28.6 (peer)
 
-- Node.js >= 24
-- Kysely >= 0.28.6
+> Page tokens are versioned but **not stable across library upgrades**. Discard outstanding tokens after upgrading.
 
 ---
 
 ## Quick start
 
-> **Warning:** This project is in early development and does not support cross-version token compatibility.
-
 ```ts
 import { Kysely } from 'kysely'
-import { createPaginator, PostgresPaginationDialect, codecPipe, superJsonCodec, base64UrlCodec } from 'kysely-cursor'
+import { createPaginator, PostgresPaginationDialect } from 'kysely-cursor'
 
-type DB = { users: { id: string; created_at: Date; email: string } }
+type DB = { posts: { id: number; title: string; created_at: Date } }
 
-const db = new Kysely<DB>({/* ... */})
+const db = new Kysely<DB>({/* … */})
 
-// Build a cursor codec: SuperJSON → Base64 URL (opaque & URL‑safe)
-const cursorCodec = codecPipe(superJsonCodec, base64UrlCodec)
-
+// Default codec: SuperJSON → Base64 URL-safe
 const paginator = createPaginator({
   dialect: new PostgresPaginationDialect(),
-  cursorCodec,
 })
 
+// Final sort must be unique & non-nullable. notNull: true unlocks faster seeks.
 const sorts = [
-  // nullable leading sorts are allowed; final sort must be unique & non‑nullable
-  { col: 'users.created_at', dir: 'desc', output: 'created_at' },
-  { col: 'users.id', dir: 'desc', output: 'id' },
+  { col: 'posts.created_at', dir: 'desc', notNull: true },
+  { col: 'posts.id', dir: 'desc' },
 ] as const
 
-const page1 = await paginator.paginate({
-  query: db.selectFrom('users').select(['id', 'email', 'created_at']),
-  sorts,
-  limit: 25,
-})
+const query = db.selectFrom('posts').select(['id', 'title', 'created_at'])
+
+const page1 = await paginator.paginate({ query, sorts, limit: 25 })
 
 const page2 = await paginator.paginate({
-  query: db.selectFrom('users').select(['id', 'email', 'created_at']),
+  query,
   sorts,
   limit: 25,
   cursor: { nextPage: page1.nextPage! },
 })
+
+// prev: cursor: { prevPage: page2.prevPage! }  // sorts inverted internally
 ```
+
+Same pattern with `MysqlPaginationDialect`, `MssqlPaginationDialect`, or `SqlitePaginationDialect`.
 
 ---
 
-## Concepts
-
-### Sorts
-
-Provide an ordered **sort set** that uniquely identifies rows:
+## Sorts
 
 ```ts
 const sorts = [
-  { col: 'users.created_at', dir: 'desc', output: 'created_at', nulls: 'last' },
-  { col: 'users.id', dir: 'desc', output: 'id' }, // final non‑nullable & unique key
+  { col: 'posts.created_at', dir: 'desc', notNull: true },
+  { col: 'posts.id', dir: 'desc' }, // unique tie-breaker
 ] as const
 ```
 
-- Leading sorts take precedence over later sorts.
-- Leading sorts may be nullable; the **final sort must be non-nullable & unique**.
-- Use a primary key or a unique index for the final sort — this acts as a tie-breaker.
-- Prefer a composite index that matches the sort, e.g. `(created_at DESC, id DESC)`.
-- `dir` is the sort direction. Defaults to `asc`.
-- `col` is the field to sort by, optionally qualified.
-- `output` is the field name in your outputted rows. Defaults to `col`, without the qualifying prefix. May need to be
-  explicitly set if your `col` is aliased in your select statement.
-- `nullable` — for **leading** keys that never contain NULL, set `nullable: false` so the library can use a simpler
-  (usually faster) keyset predicate. Omit it when the column may be null; that is also the default if you leave it out.
-  TypeScript rejects `nullable: false` on columns typed as `| null`, and `nullable: true` on non-null columns.
-- `nulls` is an optional per-sort null ordering hint:
+| Field     | Notes                                                              |
+| --------- | ------------------------------------------------------------------ |
+| `col`     | Column/expression; may be qualified                                |
+| `dir`     | `'asc'` (default) or `'desc'`                                      |
+| `output`  | Result field name; defaults to last segment of `col`               |
+| `notNull` | Leading keys only. Opt-in for seek-friendly SQL (see below)        |
+| `nulls`   | `'first'` \| `'last'` on Postgres/SQLite; throws on MySQL/MSSQL    |
 
-  ```ts
-  { col: 'users.deleted_at', dir: 'asc', nulls: 'last' }
-  ```
+- **`notNull`:** omit (default) stays null-safe even if TS says non-null. Set `notNull: true` to unlock plain OR / row compare. `notNull: false` only allowed on nullable columns.
+- Leading sorts may be nullable; the **final** sort must be non-null and unique.
+- Prefer a composite index matching the sort, e.g. `(created_at DESC, id DESC)`.
+- Use the **same** `sorts` on every request for a screen; tokens include a sort signature.
 
-  - `'first'` → place all `NULL`s before non-NULLs for that sort
-  - `'last'` → place all `NULL`s after non-NULLs for that sort
-  - If omitted, the dialect’s defaults are used (see below).
-  - On dialects that **don’t** support `NULLS FIRST / LAST` (e.g. MySQL, MSSQL), providing `nulls` will throw a
-    `PaginationError` at runtime — so only specify it when the dialect can express it.
+---
 
-### Dialects
+## Keyset SQL
 
-Built‑ins (imported from `kysely-cursor`):
+One semantic model; emission varies by sort flags and dialect:
 
-- `PostgresPaginationDialect`
-- `MysqlPaginationDialect`
-- `MssqlPaginationDialect`
-- `SqlitePaginationDialect`
+| Situation                                       | Shape (DESC)                                     |
+| ----------------------------------------------- | ------------------------------------------------ |
+| Default / explicit `nulls`                      | Null-safe OR                                     |
+| All non-final keys `notNull: true`, uniform dir | Plain OR — or **row compare** on Postgres/SQLite |
+| Same on MSSQL                                   | Plain OR                                         |
+| Same on MySQL                                   | Stays null-safe OR (optimizer-friendly)          |
 
-Construct with `new` (e.g. `new PostgresPaginationDialect()`). Custom dialects can extend `BasePaginationDialect`.
+`keysetStrategy`: `'auto'` (default — prefer row compare when allowed) or `'portable'` (never row compare).
 
-### Codecs
+**Deep-page checklist:** matching composite index · `notNull: true` on every non-null leading key · uniform directions · leave `keysetStrategy` at `auto`.
 
-Codecs are used to encode and decode the cursor to an opaque string. You can compose multiple codecs into a pipeline.
+---
 
-Provided:
+## Dialects & nulls
 
-- `superJsonCodec` — preserves Dates, BigInts, etc.
-- `base64UrlCodec` — UTF‑8 ⇄ Base64 **URL‑safe** strings.
-- `createAesCodec(secret)` — AES‑256‑GCM with scrypt‑derived key and versioned payload (
-  see [Security notes](#security-notes)).
-- `stashCodec(stash)` — stores the raw payload in external storage, returning a random UUID key.
-- `codecPipe(...codecs)` — compose multiple codecs into one.
+| Dialect    | Class                       | Row compare | `nulls`    | Default NULLs (ASC) |
+| ---------- | --------------------------- | ----------- | ---------- | ------------------- |
+| PostgreSQL | `PostgresPaginationDialect` | ✅          | ✅         | last                |
+| MySQL      | `MysqlPaginationDialect`    | —           | ❌         | first               |
+| SQL Server | `MssqlPaginationDialect`    | —           | ❌         | first               |
+| SQLite     | `SqlitePaginationDialect`   | ✅          | ✅ (3.30+) | first               |
 
-The default cursor codec is `codecPipe(superJsonCodec, base64UrlCodec)`.
+Construct with `new`. Custom engines: extend `BasePaginationDialect` and set `meta`.
 
-### Null ordering
+Omit `nulls` → dialect-native defaults. `prev` inverts direction and explicit `nulls` so the total order stays consistent.
 
-NULL placement differs between engines. Set `nulls: 'first' | 'last'` on a sort key when you need an explicit order; omit it to use the dialect default.
+---
 
-| Database System                  | Default NULLs (ASC) | Default NULLs (DESC) | Supports `NULLS FIRST / LAST`? |
-| -------------------------------- | ------------------- | -------------------- | ------------------------------ |
-| **MySQL**                        | NULLs **first**     | NULLs **last**       | ❌ Not supported               |
-| **PostgreSQL**                   | NULLs **last**      | NULLs **first**      | ✅ Fully supported             |
-| **Microsoft SQL Server (MSSQL)** | NULLs **first**     | NULLs **last**       | ❌ Not supported               |
-| **SQLite**                       | NULLs **first**     | NULLs **last**       | ✅ Supported since 3.30.0      |
+## Codecs
+
+Default: `codecPipe(superJsonCodec, base64UrlCodec)`.
+
+| Export                   | Role                            |
+| ------------------------ | ------------------------------- |
+| `superJsonCodec`         | Dates, BigInts, …               |
+| `base64UrlCodec`         | URL-safe string                 |
+| `createAesCodec(secret)` | AES-256-GCM                     |
+| `stashCodec(stash)`      | External store → UUID token     |
+| `codecPipe(…)`           | Compose left-to-right on encode |
 
 ```ts
-const sort = { col: 'posts.published_at', dir: 'asc', nulls: 'last' }
+// Encrypt tokens
+cursorCodec: codecPipe(superJsonCodec, createAesCodec(process.env.PAGINATION_SECRET!), base64UrlCodec)
+
+// Or stash server-side (e.g. Redis TTL) so tokens are short UUIDs
+cursorCodec: stashCodec({ get: (k) => redis.get(k)!, set: (k, v) => redis.set(k, v) })
 ```
 
-On dialects that support `NULLS FIRST / LAST` (Postgres, SQLite ≥ 3.30.0), this is emitted in the `ORDER BY`. On MySQL and MSSQL, providing `nulls` throws a `PaginationError` with `code: 'INVALID_SORT'` so you don’t silently get inconsistent pagination.
-
-When `nulls` is omitted, the dialect’s ascending default is used for `dir: 'asc'`, and the inverted default for `dir: 'desc'`.
+Tokens still carry sort-key **values**. Encrypt/stash if that data is sensitive; tokens are page handles, not auth.
 
 ---
 
 ## API
 
-### `createPaginator`
-
 ```ts
-import { createPaginator, type PaginatorOptions, type Paginator } from 'kysely-cursor'
-
-const paginator: Paginator = createPaginator({
-  dialect, // PaginationDialect
-  cursorCodec, // optional: Codec<any, string>; defaults to SuperJSON+Base64URL
-})
+createPaginator({
+  dialect,                              // e.g. new PostgresPaginationDialect()
+  cursorCodec?,                         // default SuperJSON → Base64URL
+  keysetStrategy?: 'auto' | 'portable', // default 'auto'
+}): Paginator  // { paginate, paginateWithEdges }
 ```
 
-Returns an object with `paginate` and `paginateWithEdges` methods that injects your defaults.
-
----
-
-### `paginate` (low-level)
-
 ```ts
-import { paginate } from 'kysely-cursor'
-
-const result = await paginate({
-  query, // Kysely SelectQueryBuilder
-  sorts, // SortSet<DB, TB, O>
-  limit, // positive integer
-  cursor, // { nextPage } | { prevPage } | { offset }
-  dialect, // PaginationDialect
-  cursorCodec, // optional
-})
-```
-
-**Return value**
-
-```ts
-export type PaginatedResult<T> = {
-  items: T[]
-  startCursor?: string
-  endCursor?: string
-  nextPage?: string
-  prevPage?: string
-  hasNextPage: boolean
-  hasPrevPage: boolean
-}
-```
-
----
-
-### `paginateWithEdges` (low-level)
-
-Identical to above, except it will return an array of `edges` that contain every
-item with a correlated `cursor`.
-
-```ts
-import { paginateWithEdges } from 'kysely-cursor'
-
-const result = await paginateWithEdges({
-  query, // Kysely SelectQueryBuilder
-  sorts, // SortSet<DB, TB, O>
-  limit, // positive integer
-  cursor, // { nextPage } | { prevPage } | { offset }
-  dialect, // PaginationDialect
-  cursorCodec, // optional
-})
-```
-
-**Return value**
-
-```ts
-export type PaginatedResultWithEdges<T> = {
-  edges: {
-    node: T
-    cursor: string
-  }[]
-  startCursor?: string
-  endCursor?: string
-  nextPage?: string
-  prevPage?: string
-  hasNextPage: boolean
-  hasPrevPage: boolean
-}
-```
-
----
-
-## Examples
-
-### Forward/back pagination
-
-```ts
-const sorts = [
-  { col: 'posts.published_at', dir: 'desc', nulls: 'last', output: 'published_at' },
-  { col: 'posts.id', dir: 'desc', output: 'id' },
-] as const
-
-const page1 = await paginator.paginate({ query: postsQ, sorts, limit: 20 })
-
-// forward
-const page2 = await paginator.paginate({
-  query: postsQ,
+// also: paginate / paginateWithEdges with the same fields inline
+await paginator.paginate({
+  query,   // SelectQueryBuilder
   sorts,
-  limit: 20,
-  cursor: { nextPage: page1.nextPage! },
-})
-
-// backward (internally inverts sorts to walk back)
-const backToPage1 = await paginator.paginate({
-  query: postsQ,
-  sorts,
-  limit: 20,
-  cursor: { prevPage: page2.prevPage! },
+  limit,   // positive integer
+  cursor?, // { nextPage } | { prevPage } | { offset }
 })
 ```
 
-### Offset fallback
-
-Useful for legacy routes or when you truly need numeric offsets:
-
-```ts
-const page3 = await paginator.paginate({
-  query: postsQ,
-  sorts,
-  limit: 20,
-  cursor: { offset: 40 }, // skip first 40 rows (page index * limit)
-})
-```
-
-### Custom codec pipelines
-
-Make tokens opaque and short:
-
-```ts
-import { codecPipe, superJsonCodec, base64UrlCodec, createAesCodec } from 'kysely-cursor'
-
-const cursorCodec = codecPipe(
-  superJsonCodec, // stable serialization (Date, BigInt, etc.)
-  createAesCodec(process.env.PAGINATION_SECRET!), // encrypt
-  base64UrlCodec, // URL‑safe string
-)
-```
-
-Or stash payload externally:
-
-```ts
-import { stashCodec } from 'kysely-cursor'
-
-const stash = {
-  get: async (key: string) => redis.get(`cursor:${key}`)!,
-  set: async (key: string, val: string) => {
-    await redis.set(`cursor:${key}`, val, { EX: 3600 })
-  },
-}
-
-const cursorCodec = stashCodec(stash)
-// Returned tokens look like random UUIDs; payload is stored in Redis.
-```
-
----
-
-## Benchmarks
-
-Cursor vs offset benchmarks for every dialect live in [`bench/`](./bench).
-
-```bash
-pnpm bench:quick          # smoke
-pnpm bench                # CI profile (deep-page + walk)
-pnpm bench -- --full      # all scenarios, dense depths
-pnpm bench:compare        # vs committed bench/baseline/
-pnpm bench:update-baseline
-```
-
-See [`bench/README.md`](./bench/README.md) for methodology, CI regression gating, and how to interpret results.
-
----
-
-## Error Handling
-
-All operational errors are thrown as a `PaginationError` with a consistent structure:
+**`paginate` result**
 
 ```ts
 {
-  message: string
-  code: ErrorCode
-  cause?: Error
+  items: T[]
+  hasNextPage: boolean
+  hasPrevPage: boolean
+  nextPage?: string
+  prevPage?: string
+  startCursor?: string
+  endCursor?: string
 }
 ```
 
-Treat these as **400 Bad Request** unless the `code` indicates an internal failure.
+`paginateWithEdges` swaps `items` for `edges: { node: T; cursor: string }[]`.
+
+**Filters** stay on the Kysely query; the paginator only applies order, limit, and the keyset predicate.
+
+### Errors
+
+`PaginationError` with `code`:
+
+| Code               | Typical cause                                          |
+| ------------------ | ------------------------------------------------------ |
+| `INVALID_TOKEN`    | Bad/old token, sort signature mismatch, invalid offset |
+| `INVALID_SORT`     | Empty sorts, unsupported `nulls`                       |
+| `INVALID_LIMIT`    | Non-positive limit                                     |
+| `UNEXPECTED_ERROR` | Internal / codec failure (`cause`)                     |
+
+Map client mistakes to **400**; `UNEXPECTED_ERROR` to **500**.
+
+---
+
+## Examples & benchmarks
+
+```bash
+pnpm example:postgres   # Compose + demos: next/prev, filters, nulls, edges, offset, full walk
+pnpm bench:quick        # smoke
+pnpm bench              # CI profile (all dialects)
+pnpm bench:compare      # vs bench/baseline/
+```
+
+Details: [`examples/postgres`](./examples/postgres) · [`bench/README.md`](./bench/README.md).
+
+CI runs lint, a Kysely version matrix, and per-dialect benches with regression checks vs `bench/baseline/`.
 
 ---
 
 ## FAQ
 
-**Why do tokens break if I change the sort order?**
-Tokens include a signature of the sort spec. If it doesn’t match, decoding fails with
-`Page token does not match sort order` to prevent mixing tokens across screens.
+**Why do tokens break when I change sorts?**  
+Tokens hash the sort spec (columns, directions, null placement). A mismatch throws so screens cannot share tokens. Treat decode failures as “start over at page 1.”
 
-**Do I have to include `output`?**
-No. If omitted, the last path segment of `col` is used (e.g., `users.created_at → created_at`). Use `output` when the
-selected column alias differs from the DB column.
+**Deep page still slow on Postgres?**  
+You’re likely still on the null-safe path. Set `notNull: true` on non-null leading keys, match a composite index, keep `keysetStrategy: 'auto'`. See the checklist above and `pnpm bench:postgres`.
 
-**Can the first page expose `prevPage`?**
-The library over‑fetches by `limit+1` to determine if there’s another page. You’ll get `prevPage` once you’ve moved
-forward; an empty result returns no tokens.
+**Do I need `output`?**  
+Only when the select alias differs from the last segment of `col`.
 
-**How are NULLs handled?**
-You can control this per sort via `nulls: 'first' | 'last'` on dialects that support it. If you omit it, the dialect’s
-declared defaults are used, and descending sorts get the inverse of the ascending default. On dialects that can’t express
-null placement, specifying `nulls` throws an error so you don’t get silent drift.
+**First page `prevPage`?**  
+Usually no. The library over-fetches `limit + 1` for `hasNextPage`. `prevPage` appears after you move forward.
 
-**When should I set `nullable: false`?**
-When a leading sort column truly has no NULLs (and you have a matching index). That lets the library use a simpler
-predicate for deep pages. Leave it unset if the column can be null — correctness comes first.
-
-**What is `keysetStrategy`?**
-Most apps never need this. Defaults to `auto` (use the best form the dialect supports). Set `portable` only if you want
-to avoid dialect-specific tuple/row comparisons:
-
-```ts
-const paginator = createPaginator({
-  dialect: new PostgresPaginationDialect(),
-  keysetStrategy: 'portable',
-})
-```
+**Force SQL without row-value compare?**  
+`keysetStrategy: 'portable'`.
 
 ---
 
-## Acknowledgements
+## Development
 
-Built on the excellent [Kysely](https://github.com/kysely-org/kysely).
+```bash
+pnpm install && pnpm build && pnpm test
+pnpm fix                              # lint + format
+./scripts/test-kysely-versions.sh     # full Kysely peer matrix (optional)
+```
+
+MIT © Luke Wood — built on [Kysely](https://github.com/kysely-org/kysely).

--- a/bench/README.md
+++ b/bench/README.md
@@ -92,27 +92,27 @@ time near ~30s per dialect (MSSQL is often higher due to container startup).
 
 ### What SQL the library emits (timed scenarios)
 
-Timed scenarios set `nullable: false` on non-null sort keys. Emission still follows
+Timed scenarios set `notNull: true` on non-null sort keys. Emission still follows
 each dialect’s capability flags (same as production):
 
-| Dialect    | With `nullable: false` (feed / score sorts)    | Notes                                                               |
+| Dialect    | With `notNull: true` (feed / score sorts)    | Notes                                                               |
 | ---------- | ---------------------------------------------- | ------------------------------------------------------------------- |
 | `postgres` | **Row compare** `(created_at, id) < ($1,$2)`   | Index Cond seek                                                     |
 | `sqlite`   | **Row compare**                                | Same family                                                         |
 | `mssql`    | **Plain OR** (no tuple compare)                | Cursor still wins; latency can grow with depth                      |
-| `mysql`    | **Null-safe OR** (even with `nullable: false`) | Intentional: plain OR / row compare often regress at depth on MySQL |
+| `mysql`    | **Null-safe OR** (even with `notNull: true`) | Intentional: plain OR / row compare often regress at depth on MySQL |
 
 Default (unmarked) leading sorts stay **null-safe OR** on every dialect. On
 Postgres that shape is typically a **Filter** over an index walk
 (`Rows Removed by Filter ≈ OFFSET`), not an Index Cond seek — so deep pages
-look ~like OFFSET unless you opt into `nullable: false`.
+look ~like OFFSET unless you opt into `notNull: true`.
 
 ```sql
 -- default / MySQL optimized path
 WHERE (created_at IS NOT NULL AND created_at < $1)
    OR (created_at IS NOT NULL AND created_at = $1 AND id IS NOT NULL AND id < $2)
 
--- Postgres / SQLite with nullable: false
+-- Postgres / SQLite with notNull: true
 WHERE (created_at, id) < ($1, $2)
 ```
 
@@ -136,7 +136,7 @@ Typical Postgres plans at depth ~1000+ (warm cache, ~800B rows):
 | Form                           | Plan shape                        | Buffers        | Exec time (order of magnitude) |
 | ------------------------------ | --------------------------------- | -------------- | ------------------------------ |
 | Library null-safe OR (default) | Index Scan + Filter, many removed | ~thousands     | ~same as OFFSET                |
-| Library `nullable: false`      | Index Cond seek                   | ~single digits | **much faster**                |
+| Library `notNull: true`      | Index Cond seek                   | ~single digits | **much faster**                |
 | Ideal row comparison (raw SQL) | Index Cond seek                   | ~same as seek  | lower bound without codec      |
 | OFFSET deep skip               | Index Scan, skip N                | ~thousands     | baseline                       |
 

--- a/bench/baseline/summary.md
+++ b/bench/baseline/summary.md
@@ -2,7 +2,7 @@
 
 **2026-07-25T19:21:03.631Z** · `ce6911c` · 50,000 rows · page 25 · iters 4/1 · walk 25 · depths [0,100,500] · postgres,mysql,mssql,sqlite · deep-page,sequential-walk
 
-Cursor = keyset via library API (`nullable: false` on non-null keys). Offset = built-in offset fallback. Speedup = offset/cursor (higher ⇒ cursor faster).
+Cursor = keyset via library API (`notNull: true` on non-null keys). Offset = built-in offset fallback. Speedup = offset/cursor (higher ⇒ cursor faster).
 
 ## Headline — deepest deep-page
 

--- a/bench/src/plans.ts
+++ b/bench/src/plans.ts
@@ -3,7 +3,7 @@ import type { DialectHandle } from './types.js'
 
 /**
  * Capture EXPLAIN output at a deep page (Postgres only via DialectHandle.explain):
- * 1. Library seek path (`nullable: false` → row compare) — matches timed deep-page
+ * 1. Library seek path (`notNull: true` → row compare) — matches timed deep-page
  * 2. Library default null-safe OR — untimed reference (often Filter ≈ OFFSET)
  * 3. OFFSET — baseline skip plan
  */
@@ -37,7 +37,7 @@ WHERE (
 ORDER BY created_at DESC, id DESC
 LIMIT ${pageSize + 1}`
 
-  // Library path for feedSorts with nullable: false on Postgres (auto → row_compare).
+  // Library path for feedSorts with notNull: true on Postgres (auto → row_compare).
   const librarySeekSql = `
 SELECT id, author_id, title, body, status, score, created_at
 FROM posts
@@ -53,7 +53,7 @@ OFFSET ${offset}
 LIMIT ${pageSize + 1}`
 
   for (const [title, q] of [
-    [`library keyset (nullable: false → row compare) at depth=${depth}`, librarySeekSql],
+    [`library keyset (notNull: true → row compare) at depth=${depth}`, librarySeekSql],
     [`library keyset (default null-safe OR) at depth=${depth}`, nullSafeSql],
     [`offset at depth=${depth} (OFFSET ${offset})`, offsetSql],
   ] as const) {

--- a/bench/src/report.ts
+++ b/bench/src/report.ts
@@ -137,7 +137,7 @@ export const renderBaselineMarkdown = (baseline: BaselineReport, full?: BenchRep
   )
   lines.push('')
   lines.push(
-    'Cursor = keyset via library API (`nullable: false` on non-null keys). ' +
+    'Cursor = keyset via library API (`notNull: true` on non-null keys). ' +
       'Offset = built-in offset fallback. Speedup = offset/cursor (higher ⇒ cursor faster).',
   )
   lines.push('')

--- a/bench/src/scenarios/deep-page.ts
+++ b/bench/src/scenarios/deep-page.ts
@@ -27,7 +27,7 @@ export const runDeepPage = async (ctx: ScenarioContext): Promise<ScenarioResult>
     scenario: 'deep-page',
     title: 'Deep page (single request at depth N)',
     description:
-      'Library API: one page at increasing depths. Cursor tokens are pre-resolved so only the page query is timed. Offset uses OFFSET = depth × pageSize. Feed sorts use nullable: false; emission is dialect-specific (PG/SQLite row compare, MSSQL plain OR, MySQL null-safe OR) plus the token codec.',
+      'Library API: one page at increasing depths. Cursor tokens are pre-resolved so only the page query is timed. Offset uses OFFSET = depth × pageSize. Feed sorts use notNull: true; emission is dialect-specific (PG/SQLite row compare, MSSQL plain OR, MySQL null-safe OR) plus the token codec.',
     samples,
     comparisons: buildComparisons(handle.name, 'deep-page', samples, labels),
   }

--- a/bench/src/scenarios/helpers.ts
+++ b/bench/src/scenarios/helpers.ts
@@ -6,7 +6,7 @@ import type { ComparisonRow, DialectHandle, Post, Sample, ScenarioContext, Scena
 
 export type QueryFactory = () => SelectQueryBuilder<any, any, Post>
 
-export type SortSpec = readonly { col: any; dir?: any; output?: any; nulls?: any; nullable?: boolean }[]
+export type SortSpec = readonly { col: any; dir?: any; output?: any; nulls?: any; notNull?: boolean }[]
 
 /**
  * Walk forward `depth` pages with keyset cursors and return the nextPage token

--- a/bench/src/scenarios/ideal-baseline.ts
+++ b/bench/src/scenarios/ideal-baseline.ts
@@ -7,7 +7,7 @@ import { measure, samplesFor, summarize } from '../metrics.js'
 import type { BenchDB, ComparisonRow, Post, Sample, ScenarioContext, ScenarioResult } from '../types.js'
 
 /**
- * Raw SQL keyset matching library emission for feed sorts with `nullable: false`.
+ * Raw SQL keyset matching library emission for feed sorts with `notNull: true`.
  *
  * | Dialect  | Library path                     | Ideal baseline SQL        |
  * |----------|----------------------------------|---------------------------|
@@ -68,11 +68,11 @@ const describeForm = (form: IdealKeysetForm): string => {
     case 'row_compare':
       return (
         'Raw keyset via row comparison `(created_at, id) < ($1, $2)` vs OFFSET — ' +
-        'same shape as library deep-page with `nullable: false` (no token codec).'
+        'same shape as library deep-page with `notNull: true` (no token codec).'
       )
     case 'null_safe_or':
       return (
-        'Raw keyset via null-safe OR (MySQL library path even with `nullable: false`) ' +
+        'Raw keyset via null-safe OR (MySQL library path even with `notNull: true`) ' +
         'vs OFFSET — no library wrappers or token codec.'
       )
     case 'plain_or':

--- a/bench/src/scenarios/scoreboard.ts
+++ b/bench/src/scenarios/scoreboard.ts
@@ -26,7 +26,7 @@ export const runScoreboard = async (ctx: ScenarioContext): Promise<ScenarioResul
     scenario: 'scoreboard',
     title: 'Scoreboard (ORDER BY score DESC, id DESC)',
     description:
-      'Full-table ranking by score with id as tie-breaker. Models leaderboards and “top N” feeds. Index: (score, id). Sorts use nullable: false (score and id are NOT NULL).',
+      'Full-table ranking by score with id as tie-breaker. Models leaderboards and “top N” feeds. Index: (score, id). Sorts use notNull: true (score and id are NOT NULL).',
     samples,
     comparisons: buildComparisons(handle.name, 'scoreboard', samples, labels),
   }

--- a/bench/src/schema.ts
+++ b/bench/src/schema.ts
@@ -6,7 +6,7 @@ import type { Post } from './types.js'
  * - scoreboard / ranking (score + id) — scoreboard scenario
  *
  * The final key is always non-null unique `id`.
- * `nullable: false` opts into seek-friendly keyset emission (row compare / plain OR);
+ * `notNull: true` opts into seek-friendly keyset emission (row compare / plain OR);
  * created_at and score are NOT NULL in the bench schema.
  */
 export const feedSorts = [
@@ -14,7 +14,7 @@ export const feedSorts = [
     col: 'posts.created_at' as const,
     dir: 'desc' as const,
     output: 'created_at' as const,
-    nullable: false as const,
+    notNull: true as const,
   },
   { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
 ]
@@ -24,7 +24,7 @@ export const scoreSorts = [
     col: 'posts.score' as const,
     dir: 'desc' as const,
     output: 'score' as const,
-    nullable: false as const,
+    notNull: true as const,
   },
   { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
 ]

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -55,7 +55,7 @@ DATABASE_URL=postgres://user:pass@localhost:5432/mydb pnpm dev
 | 5   | Numeric offset            | `cursor: { offset }`                            |
 | 6   | Full result walk          | Loop on `nextPage` until exhausted              |
 
-Supporting modules also show composite indexes matched to sort shapes, `nullable: false` for Postgres row-value seeks, pluggable codecs, and `keysetStrategy: 'auto'`.
+Supporting modules also show composite indexes matched to sort shapes, `notNull: true` for Postgres row-value seeks, pluggable codecs, and `keysetStrategy: 'auto'`.
 
 ```
 examples/postgres/

--- a/examples/postgres/demos.ts
+++ b/examples/postgres/demos.ts
@@ -5,39 +5,6 @@ import type { Database, PostRow } from './db.js'
 
 const PAGE_SIZE = 5
 
-/** Chronological feed (`nullable: false` enables Postgres row-value compare). */
-export const feedSorts = [
-  {
-    col: 'posts.created_at' as const,
-    dir: 'desc' as const,
-    output: 'created_at' as const,
-    nullable: false as const,
-  },
-  { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
-] as const
-
-/** Ranking by score. */
-export const scoreSorts = [
-  {
-    col: 'posts.score' as const,
-    dir: 'desc' as const,
-    output: 'score' as const,
-    nullable: false as const,
-  },
-  { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
-] as const
-
-/** Nullable `published_at` with `nulls: 'last'` (drafts sort after published posts). */
-export const publishedSorts = [
-  {
-    col: 'posts.published_at' as const,
-    dir: 'desc' as const,
-    output: 'published_at' as const,
-    nulls: 'last' as const,
-  },
-  { col: 'posts.id' as const, dir: 'desc' as const, output: 'id' as const },
-] as const
-
 function postsQuery(db: Kysely<Database>) {
   return db.selectFrom('posts').select(['id', 'title', 'author', 'score', 'published_at', 'created_at'])
 }
@@ -90,9 +57,13 @@ export async function demoForwardAndBack(db: Kysely<Database>, paginator: Pagina
 
   const query = postsQuery(db)
 
+  // sorts are inlined so TS checks them against this query's selected columns
   const page1 = await paginator.paginate({
     query,
-    sorts: feedSorts,
+    sorts: [
+      { col: 'posts.created_at', dir: 'desc', notNull: true },
+      { col: 'posts.id', dir: 'desc' },
+    ],
     limit: PAGE_SIZE,
   })
 
@@ -107,7 +78,10 @@ export async function demoForwardAndBack(db: Kysely<Database>, paginator: Pagina
 
   const page2 = await paginator.paginate({
     query,
-    sorts: feedSorts,
+    sorts: [
+      { col: 'posts.created_at', dir: 'desc', notNull: true },
+      { col: 'posts.id', dir: 'desc' },
+    ],
     limit: PAGE_SIZE,
     cursor: { nextPage: page1.nextPage },
   })
@@ -120,7 +94,10 @@ export async function demoForwardAndBack(db: Kysely<Database>, paginator: Pagina
 
   const back = await paginator.paginate({
     query,
-    sorts: feedSorts,
+    sorts: [
+      { col: 'posts.created_at', dir: 'desc', notNull: true },
+      { col: 'posts.id', dir: 'desc' },
+    ],
     limit: PAGE_SIZE,
     cursor: { prevPage: page2.prevPage },
   })
@@ -142,7 +119,10 @@ export async function demoFilteredFeed(db: Kysely<Database>, paginator: Paginato
 
   const page = await paginator.paginate({
     query,
-    sorts: feedSorts,
+    sorts: [
+      { col: 'posts.created_at', dir: 'desc', notNull: true },
+      { col: 'posts.id', dir: 'desc' },
+    ],
     limit: PAGE_SIZE,
   })
 
@@ -157,7 +137,10 @@ export async function demoNullablePublishedAt(db: Kysely<Database>, paginator: P
 
   const page = await paginator.paginate({
     query: postsQuery(db),
-    sorts: publishedSorts,
+    sorts: [
+      { col: 'posts.published_at', dir: 'desc', nulls: 'last' },
+      { col: 'posts.id', dir: 'desc' },
+    ],
     limit: PAGE_SIZE,
   })
 
@@ -172,7 +155,10 @@ export async function demoWithEdges(db: Kysely<Database>, paginator: Paginator) 
 
   const result = await paginator.paginateWithEdges({
     query: postsQuery(db),
-    sorts: scoreSorts,
+    sorts: [
+      { col: 'posts.score', dir: 'desc', notNull: true },
+      { col: 'posts.id', dir: 'desc' },
+    ],
     limit: 3,
   })
 
@@ -195,7 +181,10 @@ export async function demoOffsetFallback(db: Kysely<Database>, paginator: Pagina
 
   const page = await paginator.paginate({
     query: postsQuery(db),
-    sorts: feedSorts,
+    sorts: [
+      { col: 'posts.created_at', dir: 'desc', notNull: true },
+      { col: 'posts.id', dir: 'desc' },
+    ],
     limit: PAGE_SIZE,
     cursor: { offset: PAGE_SIZE },
   })
@@ -217,7 +206,10 @@ export async function demoWalkAll(db: Kysely<Database>, paginator: Paginator) {
   for (;;) {
     const page = await paginator.paginate({
       query,
-      sorts: feedSorts,
+      sorts: [
+        { col: 'posts.created_at', dir: 'desc', notNull: true },
+        { col: 'posts.id', dir: 'desc' },
+      ],
       limit: PAGE_SIZE,
       cursor,
     })

--- a/src/dialect/mysql.ts
+++ b/src/dialect/mysql.ts
@@ -8,7 +8,7 @@ export class MysqlPaginationDialect extends BasePaginationDialect {
     supportsNullSortDirective: false,
     defaultNullsSortAsc: 'first' as const,
     // Benches: null-safe OR seeks well; both plain OR and row compare regress badly
-    // at depth when nullable: false opts out of the null-safe tree. Stay on null_safe_or.
+    // at depth when notNull: true opts out of the null-safe tree. Stay on null_safe_or.
     supportsRowValueCompare: false,
     supportsPlainOrKeyset: false,
   }

--- a/src/keyset.ts
+++ b/src/keyset.ts
@@ -44,8 +44,8 @@ export const classifyKeyset = (sorts: SortSet<any, any, any>, payload: CursorPay
     if (sort.nulls === 'first' || sort.nulls === 'last') return { kind: 'null_safe' }
 
     if (!isLast) {
-      if (sort.nullable !== false) return { kind: 'null_safe' }
-      // Null on a "non-null" leading key → fall back to null-safe SQL.
+      if (sort.notNull !== true) return { kind: 'null_safe' }
+      // Null on a "notNull" leading key → fall back to null-safe SQL.
       if (value === null) return { kind: 'null_safe' }
     }
   }

--- a/src/sorting.ts
+++ b/src/sorting.ts
@@ -19,12 +19,12 @@ type Sortable = string | number | boolean | Date | bigint
 type IsAny<T> = 0 extends 1 & T ? true : false
 
 /**
- * Constrain `nullable` to the selected column type in `O`:
- * null → omit/`true`; non-null → omit/`false`; `any` → `boolean`.
- * Runtime still treats omit as nullable (null-safe path).
+ * Constrain `notNull` to the selected column type in `O`:
+ * non-null → omit/`true`; null → omit/`false`; `any` → `boolean`.
+ * Runtime treats omit as null-safe; only `notNull: true` unlocks seek-friendly SQL.
  */
-type NullableProp<Col> =
-  IsAny<Col> extends true ? { nullable?: boolean } : null extends Col ? { nullable?: true } : { nullable?: false }
+type NotNullProp<Col> =
+  IsAny<Col> extends true ? { notNull?: boolean } : null extends Col ? { notNull?: false } : { notNull?: true }
 
 type SortItemCommon<Allowed> = {
   dir?: OrderByDirection
@@ -41,7 +41,7 @@ type SortItemWithOutput<
 > = SortItemCommon<Allowed> & {
   col: ReferenceExpression<DB, TB>
   output: K
-} & NullableProp<O[K]>
+} & NotNullProp<O[K]>
 
 type SortItemFromCol<
   DB,
@@ -51,9 +51,9 @@ type SortItemFromCol<
   K extends MatchingKeys<O, Allowed>,
 > = SortItemCommon<Allowed> & {
   col: StringReference<DB, TB> & OptionallyQualifiedKey<TB, K>
-} & NullableProp<O[K]>
+} & NotNullProp<O[K]>
 
-/** One sort key; `nullable` is constrained by the selected field type on `O`. */
+/** One sort key; `notNull` is constrained by the selected field type on `O`. */
 export type SortItem<DB, TB extends keyof DB, O, Allowed> = {
   [K in MatchingKeys<O, Allowed>]: SortItemWithOutput<DB, TB, O, Allowed, K> | SortItemFromCol<DB, TB, O, Allowed, K>
 }[MatchingKeys<O, Allowed>]

--- a/test/dialect/shared.ts
+++ b/test/dialect/shared.ts
@@ -753,15 +753,15 @@ export const runSharedTests = (
     expect(seen.map((r) => r.id)).toEqual(expected.map((r) => r.id))
   })
 
-  // ── keyset predicate optimization (nullable: false → plain OR / row compare) ──
+  // ── keyset predicate optimization (notNull: true → plain OR / row compare) ──
 
   it('paginates non-null marked uniform sorts equivalently to the default path', async () => {
     const { baseBuilder, fetchAllPlainSorted, paginator } = createHelpers()
 
-    // Same logical order as the unmarked default; nullable: false opts into the
+    // Same logical order as the unmarked default; notNull: true opts into the
     // fast emission path (plain OR / row compare depending on dialect).
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const expected = await fetchAllPlainSorted(sorts)
@@ -808,7 +808,7 @@ export const runSharedTests = (
   it('paginates non-null marked mixed-direction sorts (never row compare)', async () => {
     const { fetchAllPlainSorted, page } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'asc' },
     ]
     const expected = await fetchAllPlainSorted(sorts)
@@ -825,7 +825,7 @@ export const runSharedTests = (
   it('honors keysetStrategy portable for non-null marked sorts', async () => {
     const { baseBuilder, dialect, fetchAllPlainSorted } = createHelpers()
     const sorts: SortSet<TestDB, 'users', TestRow> = [
-      { col: 'users.created_at', dir: 'asc', nullable: false },
+      { col: 'users.created_at', dir: 'asc', notNull: true },
       { col: 'users.id', dir: 'asc' },
     ]
     const expected = await fetchAllPlainSorted(sorts)

--- a/test/keyset.test.ts
+++ b/test/keyset.test.ts
@@ -55,7 +55,7 @@ const payloadFor = (sorts: SortSet<DB, 'users', UserRow>, k: Record<string, unkn
 })
 
 describe('classifyKeyset', () => {
-  it('defaults leading sorts to null_safe when nullable is omitted', () => {
+  it('defaults leading sorts to null_safe when notNull is omitted', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
       { col: 'users.created_at', dir: 'desc' },
       { col: 'users.id', dir: 'desc' },
@@ -68,9 +68,9 @@ describe('classifyKeyset', () => {
     expect(classifyKeyset(sorts, payload)).toEqual({ kind: 'null_safe' })
   })
 
-  it('classifies simple_non_null when all non-final sorts set nullable: false', () => {
+  it('classifies simple_non_null when all non-final sorts set notNull: true', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const payload = payloadFor(sorts, {
@@ -86,11 +86,11 @@ describe('classifyKeyset', () => {
 
   it('detects uniform ASC and mixed directions', () => {
     const asc: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'asc', nullable: false },
+      { col: 'users.created_at', dir: 'asc', notNull: true },
       { col: 'users.id', dir: 'asc' },
     ]
     const mixed: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'asc' },
     ]
     const k = { created_at: new Date('2023-01-01'), id: 1 }
@@ -105,11 +105,11 @@ describe('classifyKeyset', () => {
     })
   })
 
-  it('forces null_safe when any sort has explicit nulls, even with nullable: false', () => {
+  it('forces null_safe when any sort has explicit nulls, even with notNull: true', () => {
     // Intentional misconfig vs row types: name is string | null, but runtime may still
-    // see nullable: false + nulls and must force the null-safe path.
+    // see notNull: true + nulls and must force the null-safe path.
     const sorts = [
-      { col: 'users.name', dir: 'asc', nullable: false, nulls: 'last' },
+      { col: 'users.name', dir: 'asc', notNull: true, nulls: 'last' },
       { col: 'users.id', dir: 'asc' },
     ] as unknown as SortSet<DB, 'users', UserRow>
     const payload = payloadFor(sorts, { name: 'A', id: 1 })
@@ -118,9 +118,9 @@ describe('classifyKeyset', () => {
   })
 
   it('forces null_safe when a non-final cursor value is null', () => {
-    // Intentional misconfig: nullable: false on a nullable-typed column with a null cursor value.
+    // Intentional misconfig: notNull: true on a nullable-typed column with a null cursor value.
     const sorts = [
-      { col: 'users.name', dir: 'asc', nullable: false },
+      { col: 'users.name', dir: 'asc', notNull: true },
       { col: 'users.id', dir: 'asc' },
     ] as unknown as SortSet<DB, 'users', UserRow>
     const payload = payloadFor(sorts, { name: null, id: 1 })
@@ -130,7 +130,7 @@ describe('classifyKeyset', () => {
 
   it('rejects a null final cursor value as INVALID_TOKEN', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const payload = payloadFor(sorts, {
@@ -143,7 +143,7 @@ describe('classifyKeyset', () => {
 
   it('rejects a missing cursor key as INVALID_TOKEN', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const payload = payloadFor(sorts, { created_at: new Date('2023-01-01') })
@@ -210,7 +210,7 @@ describe('selectKeysetStrategy', () => {
 describe('buildPlainOrPredicate', () => {
   it('emits classic multi-column OR without null guards (DESC)', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const createdAt = new Date('2023-01-01')
@@ -236,7 +236,7 @@ describe('buildPlainOrPredicate', () => {
 
   it('emits classic multi-column OR without null guards (ASC)', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'asc', nullable: false },
+      { col: 'users.created_at', dir: 'asc', notNull: true },
       { col: 'users.id', dir: 'asc' },
     ]
     const createdAt = new Date('2023-01-01')
@@ -296,7 +296,7 @@ describe('buildRowComparePredicate', () => {
 
   it('rejects null final and missing keys', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const eb = makeEb()
@@ -312,7 +312,7 @@ describe('buildRowComparePredicate', () => {
 
   it('returns a SQL fragment for multi-column uniform sorts', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const payload = payloadFor(sorts, { created_at: new Date('2023-01-01'), id: 42 })
@@ -344,9 +344,9 @@ describe('emitKeysetPredicate', () => {
     expect(json).toContain('"users.created_at"')
   })
 
-  it('uses plain_or when portable + nullable: false', () => {
+  it('uses plain_or when portable + notNull: true', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const createdAt = new Date('2023-01-01')
@@ -364,7 +364,7 @@ describe('emitKeysetPredicate', () => {
 
   it('uses plain_or for mixed directions even when dialect supports row compare', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'asc' },
     ]
     const createdAt = new Date('2023-01-01')
@@ -390,7 +390,7 @@ describe('emitKeysetPredicate', () => {
 
   it('selects row_compare for auto + supporting dialect + uniform non-null sorts', () => {
     const sorts: SortSet<DB, 'users', UserRow> = [
-      { col: 'users.created_at', dir: 'desc', nullable: false },
+      { col: 'users.created_at', dir: 'desc', notNull: true },
       { col: 'users.id', dir: 'desc' },
     ]
     const payload = payloadFor(sorts, { created_at: new Date('2023-01-01'), id: 42 })

--- a/test/pagination.test-d.ts
+++ b/test/pagination.test-d.ts
@@ -70,13 +70,13 @@ const validSortsWithBigint: SortSet<DB, 'users', UserRow> = [
   { col: 'users.id', output: 'id', dir: 'asc' },
 ]
 
-const validSortsNullableFalseOnNonNull: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', dir: 'desc', nullable: false },
+const validSortsNotNullTrueOnNonNull: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', notNull: true },
   { col: 'users.id', dir: 'desc' },
 ]
 
-const validSortsNullableTrueOnNullable: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.name', dir: 'asc', nullable: true },
+const validSortsNotNullFalseOnNullable: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.name', dir: 'asc', notNull: false },
   { col: 'users.id', dir: 'desc' },
 ]
 
@@ -86,7 +86,7 @@ const validSortsOmitOnNullable: SortSet<DB, 'users', UserRow> = [
   { col: 'users.id', dir: 'desc' },
 ]
 
-/** Explicit: omit on a non-null leading column is allowed (runtime still null-safe until false). */
+/** Explicit: omit on a non-null leading column is allowed (runtime still null-safe until notNull: true). */
 const validSortsOmitOnNonNull: SortSet<DB, 'users', UserRow> = [
   { col: 'users.created_at', dir: 'desc' },
   { col: 'users.id', dir: 'desc' },
@@ -94,40 +94,40 @@ const validSortsOmitOnNonNull: SortSet<DB, 'users', UserRow> = [
 
 /** Unqualified col names (single-table style). */
 const validSortsUnqualified: SortSet<DB, 'users', UserRow> = [
-  { col: 'name', dir: 'asc', nullable: true },
-  { col: 'created_at', dir: 'desc', nullable: false },
+  { col: 'name', dir: 'asc', notNull: false },
+  { col: 'created_at', dir: 'desc', notNull: true },
   { col: 'id', dir: 'desc' },
 ]
 
 /** Multi-leading mix: non-null, nullable, non-null final — correct flags. */
 const validSortsThreeKeyMix: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', dir: 'desc', nullable: false },
-  { col: 'users.rating', dir: 'desc', nullable: true },
+  { col: 'users.created_at', dir: 'desc', notNull: true },
+  { col: 'users.rating', dir: 'desc', notNull: false },
   { col: 'users.id', dir: 'desc' },
 ]
 
-/** Final key may omit or set nullable: false (column is already required non-null). */
-const validSortsFinalNullableFalse: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', dir: 'desc', nullable: false },
-  { col: 'users.id', dir: 'desc', nullable: false },
+/** Final key may omit or set notNull: true (column is already required non-null). */
+const validSortsFinalNotNullTrue: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', notNull: true },
+  { col: 'users.id', dir: 'desc', notNull: true },
 ]
 
 /** Expression col + output: nullability follows O[output]. */
 const validSortsExpressionOutput: SortSet<DB, 'users', UserRow> = [
-  { col: sql`lower(name)`, output: 'name', dir: 'asc', nullable: true },
+  { col: sql`lower(name)`, output: 'name', dir: 'asc', notNull: false },
   { col: sql`id`, output: 'id', dir: 'desc' },
 ]
 
 /** Projected row: flags follow projected field types, not table columns. */
 const validSortsProjected: SortSet<DB, 'users', ProjectedRow> = [
-  { col: sql`users.name`, output: 'display_name', dir: 'asc', nullable: true },
-  { col: sql`users.created_at`, output: 'feed_at', dir: 'desc', nullable: false },
+  { col: sql`users.name`, output: 'display_name', dir: 'asc', notNull: false },
+  { col: sql`users.created_at`, output: 'feed_at', dir: 'desc', notNull: true },
   { col: sql`users.id`, output: 'id', dir: 'desc' },
 ]
 
 // Concrete SortSets remain assignable into the erased runtime form used by helpers.
-const _erasedRuntimeSorts: SortSet<any, any, any> = validSortsNullableFalseOnNonNull
-const _erasedRuntimeNullable: SortSet<any, any, any> = validSortsNullableTrueOnNullable
+const _erasedRuntimeSorts: SortSet<any, any, any> = validSortsNotNullTrueOnNonNull
+const _erasedRuntimeNullable: SortSet<any, any, any> = validSortsNotNullFalseOnNullable
 const _erasedRuntimeThreeKey: SortSet<any, any, any> = validSortsThreeKeyMix
 
 // @ts-expect-error - last sort must be non-nullable sortable
@@ -136,99 +136,98 @@ const _badLastNullable: SortSet<DB, 'users', UserRow> = [
   { col: 'users.name', output: 'name', dir: 'asc' },
 ]
 
-// @ts-expect-error - nullable: false is not allowed on a nullable column (name)
-const _badNullableFalseOnNullableCol: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.name', dir: 'asc', nullable: false },
+// @ts-expect-error - notNull: true is not allowed on a nullable column (name)
+const _badNotNullTrueOnNullableCol: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.name', dir: 'asc', notNull: true },
   { col: 'users.id', dir: 'desc' },
 ]
 
-// @ts-expect-error - nullable: false is not allowed on a nullable column (via output)
-const _badNullableFalseOnNullableOutput: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.name', output: 'name', nullable: false },
+// @ts-expect-error - notNull: true is not allowed on a nullable column (via output)
+const _badNotNullTrueOnNullableOutput: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.name', output: 'name', notNull: true },
   { col: 'users.id', dir: 'desc' },
 ]
 
-// @ts-expect-error - nullable: true is not allowed on a non-null column (created_at)
-const _badNullableTrueOnNonNullCol: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', dir: 'desc', nullable: true },
+// @ts-expect-error - notNull: false is not allowed on a non-null column (created_at)
+const _badNotNullFalseOnNonNullCol: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', notNull: false },
   { col: 'users.id', dir: 'desc' },
 ]
 
-// @ts-expect-error - nullable: true is not allowed on a non-null column (via output)
-const _badNullableTrueOnNonNullOutput: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', output: 'created_at', nullable: true },
+// @ts-expect-error - notNull: false is not allowed on a non-null column (via output)
+const _badNotNullFalseOnNonNullOutput: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', output: 'created_at', notNull: false },
   { col: 'users.id', dir: 'desc' },
 ]
 
-// @ts-expect-error - unqualified: nullable: false on nullable name
-const _badUnqualifiedNullableFalse: SortSet<DB, 'users', UserRow> = [
-  { col: 'name', dir: 'asc', nullable: false },
+// @ts-expect-error - unqualified: notNull: true on nullable name
+const _badUnqualifiedNotNullTrue: SortSet<DB, 'users', UserRow> = [
+  { col: 'name', dir: 'asc', notNull: true },
   { col: 'id', dir: 'desc' },
 ]
 
-// @ts-expect-error - unqualified: nullable: true on non-null created_at
-const _badUnqualifiedNullableTrue: SortSet<DB, 'users', UserRow> = [
-  { col: 'created_at', dir: 'desc', nullable: true },
+// @ts-expect-error - unqualified: notNull: false on non-null created_at
+const _badUnqualifiedNotNullFalse: SortSet<DB, 'users', UserRow> = [
+  { col: 'created_at', dir: 'desc', notNull: false },
   { col: 'id', dir: 'desc' },
 ]
 
 // @ts-expect-error - three-key mix: wrong flag only on middle nullable key
 const _badThreeKeyMiddleFalse: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', dir: 'desc', nullable: false },
-  { col: 'users.rating', dir: 'desc', nullable: false },
+  { col: 'users.created_at', dir: 'desc', notNull: true },
+  { col: 'users.rating', dir: 'desc', notNull: true },
   { col: 'users.id', dir: 'desc' },
 ]
 
 // @ts-expect-error - three-key mix: wrong flag only on leading non-null key
 const _badThreeKeyLeadingTrue: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', dir: 'desc', nullable: true },
-  { col: 'users.rating', dir: 'desc', nullable: true },
+  { col: 'users.created_at', dir: 'desc', notNull: false },
+  { col: 'users.rating', dir: 'desc', notNull: false },
   { col: 'users.id', dir: 'desc' },
 ]
 
-// @ts-expect-error - final key is non-null; nullable: true is not allowed
-const _badFinalNullableTrue: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', dir: 'desc', nullable: false },
-  { col: 'users.id', dir: 'desc', nullable: true },
+// @ts-expect-error - final key is non-null; notNull: false is not allowed
+const _badFinalNotNullFalse: SortSet<DB, 'users', UserRow> = [
+  { col: 'users.created_at', dir: 'desc', notNull: true },
+  { col: 'users.id', dir: 'desc', notNull: false },
 ]
 
-// @ts-expect-error - expression+output: false on nullable O[output]
-const _badExpressionOutputFalse: SortSet<DB, 'users', UserRow> = [
-  { col: sql`lower(name)`, output: 'name', dir: 'asc', nullable: false },
+// @ts-expect-error - expression+output: notNull: true on nullable O[output]
+const _badExpressionOutputNotNullTrue: SortSet<DB, 'users', UserRow> = [
+  { col: sql`lower(name)`, output: 'name', dir: 'asc', notNull: true },
   { col: sql`id`, output: 'id', dir: 'desc' },
 ]
 
-// @ts-expect-error - expression+output: true on non-null O[output]
-const _badExpressionOutputTrue: SortSet<DB, 'users', UserRow> = [
-  { col: sql`created_at`, output: 'created_at', dir: 'desc', nullable: true },
+// @ts-expect-error - expression+output: notNull: false on non-null O[output]
+const _badExpressionOutputNotNullFalse: SortSet<DB, 'users', UserRow> = [
+  { col: sql`created_at`, output: 'created_at', dir: 'desc', notNull: false },
   { col: sql`id`, output: 'id', dir: 'desc' },
 ]
 
-// @ts-expect-error - projected O: false on nullable display_name
-const _badProjectedFalse: SortSet<DB, 'users', ProjectedRow> = [
-  { col: sql`users.name`, output: 'display_name', nullable: false },
+// @ts-expect-error - projected O: notNull: true on nullable display_name
+const _badProjectedNotNullTrue: SortSet<DB, 'users', ProjectedRow> = [
+  { col: sql`users.name`, output: 'display_name', notNull: true },
   { col: sql`users.id`, output: 'id' },
 ]
 
-// @ts-expect-error - projected O: true on non-null feed_at
-const _badProjectedTrue: SortSet<DB, 'users', ProjectedRow> = [
-  { col: sql`users.created_at`, output: 'feed_at', nullable: true },
+// @ts-expect-error - projected O: notNull: false on non-null feed_at
+const _badProjectedNotNullFalse: SortSet<DB, 'users', ProjectedRow> = [
+  { col: sql`users.created_at`, output: 'feed_at', notNull: false },
   { col: sql`users.id`, output: 'id' },
 ]
 
 // Widened `boolean` (not a true/false literal) is rejected once constrained to true|false.
 // Use `declare` so the binding is not narrowed by a literal initializer.
-declare const _widenedFalse: boolean
-// @ts-expect-error - boolean is not assignable to literal false on non-null column
+declare const _widenedNotNull: boolean
+// @ts-expect-error - boolean is not assignable to literal true on non-null column
 const _badWidenedBooleanOnNonNull: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.created_at', dir: 'desc', nullable: _widenedFalse },
+  { col: 'users.created_at', dir: 'desc', notNull: _widenedNotNull },
   { col: 'users.id', dir: 'desc' },
 ]
 
-declare const _widenedTrue: boolean
-// @ts-expect-error - boolean is not assignable to literal true on nullable column
+// @ts-expect-error - boolean is not assignable to literal false on nullable column
 const _badWidenedBooleanOnNullable: SortSet<DB, 'users', UserRow> = [
-  { col: 'users.name', dir: 'asc', nullable: _widenedTrue },
+  { col: 'users.name', dir: 'asc', notNull: _widenedNotNull },
   { col: 'users.id', dir: 'desc' },
 ]
 
@@ -342,19 +341,19 @@ describe('paginate (type-level)', () => {
     })
   })
 
-  it('accepts matching nullable flags (omit, true, false) across SortSet shapes', async () => {
+  it('accepts matching notNull flags (omit, true, false) across SortSet shapes', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
     const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
 
-    await paginator.paginate<DB, 'users', UserRow, typeof validSortsNullableFalseOnNonNull>({
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsNotNullTrueOnNonNull>({
       query: builder,
-      sorts: validSortsNullableFalseOnNonNull,
+      sorts: validSortsNotNullTrueOnNonNull,
       limit: 10,
     })
 
-    await paginator.paginate<DB, 'users', UserRow, typeof validSortsNullableTrueOnNullable>({
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsNotNullFalseOnNullable>({
       query: builder,
-      sorts: validSortsNullableTrueOnNullable,
+      sorts: validSortsNotNullFalseOnNullable,
       limit: 10,
     })
 
@@ -382,9 +381,9 @@ describe('paginate (type-level)', () => {
       limit: 10,
     })
 
-    await paginator.paginate<DB, 'users', UserRow, typeof validSortsFinalNullableFalse>({
+    await paginator.paginate<DB, 'users', UserRow, typeof validSortsFinalNotNullTrue>({
       query: builder,
-      sorts: validSortsFinalNullableFalse,
+      sorts: validSortsFinalNotNullTrue,
       limit: 10,
     })
 
@@ -402,7 +401,7 @@ describe('paginate (type-level)', () => {
     })
   })
 
-  it('rejects nullable mismatches on inline paginate sorts (user DX path)', async () => {
+  it('rejects notNull mismatches on inline paginate sorts (user DX path)', async () => {
     const builder = makeBuilder<DB, 'users', UserRow>([])
     const paginator = createPaginator({ dialect: new PostgresPaginationDialect() })
 
@@ -430,8 +429,8 @@ describe('paginate (type-level)', () => {
     await paginator.paginate({
       query: builder,
       sorts: [
-        { col: 'users.created_at', dir: 'desc', nullable: false },
-        { col: 'users.name', dir: 'asc', nullable: true },
+        { col: 'users.created_at', dir: 'desc', notNull: true },
+        { col: 'users.name', dir: 'asc', notNull: false },
         { col: 'users.id', dir: 'desc' },
       ],
       limit: 10,
@@ -439,9 +438,9 @@ describe('paginate (type-level)', () => {
 
     await paginator.paginate({
       query: builder,
-      // @ts-expect-error - inline: nullable: false on nullable name
+      // @ts-expect-error - inline: notNull: true on nullable name
       sorts: [
-        { col: 'users.name', dir: 'asc', nullable: false },
+        { col: 'users.name', dir: 'asc', notNull: true },
         { col: 'users.id', dir: 'desc' },
       ],
       limit: 10,
@@ -449,9 +448,9 @@ describe('paginate (type-level)', () => {
 
     await paginator.paginate({
       query: builder,
-      // @ts-expect-error - inline: nullable: true on non-null created_at
+      // @ts-expect-error - inline: notNull: false on non-null created_at
       sorts: [
-        { col: 'users.created_at', dir: 'desc', nullable: true },
+        { col: 'users.created_at', dir: 'desc', notNull: false },
         { col: 'users.id', dir: 'desc' },
       ],
       limit: 10,
@@ -461,8 +460,8 @@ describe('paginate (type-level)', () => {
       query: builder,
       // @ts-expect-error - inline: wrong flag on middle key of a three-key sort
       sorts: [
-        { col: 'users.created_at', dir: 'desc', nullable: false },
-        { col: 'users.rating', dir: 'desc', nullable: false },
+        { col: 'users.created_at', dir: 'desc', notNull: true },
+        { col: 'users.rating', dir: 'desc', notNull: true },
         { col: 'users.id', dir: 'desc' },
       ],
       limit: 10,
@@ -470,9 +469,9 @@ describe('paginate (type-level)', () => {
 
     await paginator.paginateWithEdges({
       query: builder,
-      // @ts-expect-error - inline edges path: nullable: false on nullable name
+      // @ts-expect-error - inline edges path: notNull: true on nullable name
       sorts: [
-        { col: 'users.name', dir: 'asc', nullable: false },
+        { col: 'users.name', dir: 'asc', notNull: true },
         { col: 'users.id', dir: 'desc' },
       ],
       limit: 10,


### PR DESCRIPTION
## Summary
- Replace sort opt-in `nullable` with inverted `notNull` (omit = null-safe; `notNull: true` unlocks seek SQL)
- Rewrite root README; update tests, benches, and Postgres demos

## Test plan
- [x] `pnpm test`
- [x] `pnpm --filter kysely-cursor-example-postgres typecheck`