### PR TITLE
docs: clarify 0.2.0 breaking notes in changesets

### DIFF
--- a/.changeset/keyset-predicate-optimization.md
+++ b/.changeset/keyset-predicate-optimization.md
@@ -2,4 +2,4 @@
 'kysely-cursor': minor
 ---
 
-Optimize keyset WHERE emission for non-null sorts: optional `notNull: true` on sort items, dialect-aware plain OR / row-value compare, and `keysetStrategy` (`auto` | `portable`). Default (unmarked) leading sorts stay on the null-safe path.
+Optimize keyset WHERE emission for non-null sorts: optional `notNull: true` on sort items, dialect-aware plain OR / row-value compare, and `keysetStrategy` (`auto` | `portable`). Unmarked leading sorts stay on the null-safe path; set `notNull: true` to unlock seek-friendly SQL.

--- a/.changeset/nulls-sort-support.md
+++ b/.changeset/nulls-sort-support.md
@@ -2,4 +2,10 @@
 'kysely-cursor': minor
 ---
 
-Add dialect-aware null sorting: optional `nulls: 'first' | 'last'` on sort items, `BasePaginationDialect` with `DialectMeta`, and null-safe keyset predicates that follow each engine's default NULL placement. Dialects are now classes (`new PostgresPaginationDialect()`). Cursor payloads include a version field; PostgreSQL no longer forces NULLS FIRST/LAST on every ORDER BY when `nulls` is omitted.
+Dialect-aware null sorting (`nulls: 'first' | 'last'`), `BasePaginationDialect` / `DialectMeta`, and null-safe keyset predicates that follow each engine’s default NULL placement.
+
+**Breaking**
+
+- Built-in dialects are classes: use `new PostgresPaginationDialect()` (etc.).
+- Cursor payloads are versioned (`v: 1`); tokens from 0.1.0 are rejected.
+- PostgreSQL no longer forces NULLS FIRST/LAST on every `ORDER BY` when `nulls` is omitted; engine defaults apply (ASC → nulls last).


### PR DESCRIPTION
## Summary

- Spell out 0.2.0 **Breaking** notes (dialects, cursors, Postgres nulls) in the nulls changeset.
- Tighten the keyset changeset wording for `notNull`.

## Test plan

- [ ] Confirm both changesets look right under `pnpm changeset version` (or release dry-run).