### PR TITLE
fix: scan remediation for packaging, codecs, and pagination

### DIFF
--- a/.changeset/scan-remediation.md
+++ b/.changeset/scan-remediation.md
@@ -1,0 +1,5 @@
+---
+'kysely-cursor': minor
+---
+
+Remediations for the 0.2 line: ESM-only package (drop CJS entry; Node `engines` ≥ 20), export sort/cursor types (`SortSet`, `CursorPayload`, `CURSOR_VERSION`, `Stash`, …) as types, export `emitKeysetPredicate`, optional `maxLimit`, empty offset past end sets `hasPrevPage` without inventing a keyset prev, AES codec derives key once (payload v2 — discard outstanding encrypted tokens; high-entropy secret ≥ 16), `base64UrlCodec` validates alphabet, `Stash.get` may return null, and README footguns / offset hybrid docs.

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ Omit `nulls` → dialect-native defaults. `prev` inverts direction and explicit 
 
 Default: `codecPipe(superJsonCodec, base64UrlCodec)`.
 
-| Export                   | Role                                              |
-| ------------------------ | ------------------------------------------------- |
-| `superJsonCodec`         | Dates, BigInts, …                                 |
-| `base64UrlCodec`         | URL-safe string                                   |
-| `createAesCodec(secret)` | AES-256-GCM                                       |
-| `stashCodec(stash)`      | External store → UUID token                       |
-| `codecPipe(…)`           | Compose left-to-right on encode                   |
+| Export                   | Role                            |
+| ------------------------ | ------------------------------- |
+| `superJsonCodec`         | Dates, BigInts, …               |
+| `base64UrlCodec`         | URL-safe string                 |
+| `createAesCodec(secret)` | AES-256-GCM                     |
+| `stashCodec(stash)`      | External store → UUID token     |
+| `codecPipe(…)`           | Compose left-to-right on encode |
 
 ```ts
 // Encrypt tokens

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Cursor-based (keyset) pagination for [Kysely](https://github.com/kysely-org/kyse
 
 `OFFSET … LIMIT` is simple but deep pages get slower and concurrent writes can skip/duplicate rows. **Keyset pagination** seeks from the boundary row’s sort keys (e.g. `(created_at, id)`) so the engine can use an index range instead of skipping rows.
 
-Offset is still available as `cursor: { offset }` for legacy numeric pages.
+Offset is still available as `cursor: { offset }` for legacy numeric pages. That path is a hybrid: mid-window results can mint keyset tokens, but empty offset-past-end pages set `hasPrevPage` without a `prevPage` token (see [API](#api)).
 
 ---
 
@@ -29,9 +29,9 @@ Offset is still available as `cursor: { offset }` for legacy numeric pages.
 pnpm add kysely-cursor   # or: npm i / yarn add
 ```
 
-Kysely ≥ 0.28.6 (peer)
+Node ≥ 20 · ESM-only · Kysely ≥ 0.28.6 (peer)
 
-> Page tokens are versioned but **not stable across library upgrades**. Discard outstanding tokens after upgrading.
+> Page tokens are versioned but **not guaranteed stable across upgrades**.
 
 ---
 
@@ -91,10 +91,10 @@ const sorts = [
 | `notNull` | Leading keys only. Opt-in for seek-friendly SQL (see below)     |
 | `nulls`   | `'first'` \| `'last'` on Postgres/SQLite; throws on MySQL/MSSQL |
 
-- **`notNull`:** omit (default) stays null-safe even if TS says non-null. Set `notNull: true` to unlock plain OR / row compare. `notNull: false` only allowed on nullable columns.
+- **`notNull`:** omit (default) stays null-safe even if TS says non-null. Set `notNull: true` to unlock plain OR / row compare. `notNull: false` only allowed on nullable columns. The column must actually be non-null at runtime.
 - Leading sorts may be nullable; the **final** sort must be non-null and unique.
 - Prefer a composite index matching the sort, e.g. `(created_at DESC, id DESC)`.
-- Use the **same** `sorts` on every request for a screen; tokens include a sort signature.
+- Use the **same** `sorts` on every request for a screen (including `col` qualification / `output`); tokens include a sort signature.
 
 ---
 
@@ -134,20 +134,20 @@ Omit `nulls` → dialect-native defaults. `prev` inverts direction and explicit 
 
 Default: `codecPipe(superJsonCodec, base64UrlCodec)`.
 
-| Export                   | Role                            |
-| ------------------------ | ------------------------------- |
-| `superJsonCodec`         | Dates, BigInts, …               |
-| `base64UrlCodec`         | URL-safe string                 |
-| `createAesCodec(secret)` | AES-256-GCM                     |
-| `stashCodec(stash)`      | External store → UUID token     |
-| `codecPipe(…)`           | Compose left-to-right on encode |
+| Export                   | Role                                              |
+| ------------------------ | ------------------------------------------------- |
+| `superJsonCodec`         | Dates, BigInts, …                                 |
+| `base64UrlCodec`         | URL-safe string                                   |
+| `createAesCodec(secret)` | AES-256-GCM                                       |
+| `stashCodec(stash)`      | External store → UUID token                       |
+| `codecPipe(…)`           | Compose left-to-right on encode                   |
 
 ```ts
 // Encrypt tokens
 cursorCodec: codecPipe(superJsonCodec, createAesCodec(process.env.PAGINATION_SECRET!), base64UrlCodec)
 
-// Or stash server-side (e.g. Redis TTL) so tokens are short UUIDs
-cursorCodec: stashCodec({ get: (k) => redis.get(k)!, set: (k, v) => redis.set(k, v) })
+// Or stash server-side (e.g. Redis TTL) so tokens are short UUIDs.
+cursorCodec: stashCodec({ get: (k) => redis.get(k), set: (k, v) => redis.set(k, v) })
 ```
 
 Tokens still carry sort-key **values**. Encrypt/stash if that data is sensitive; tokens are page handles, not auth.
@@ -161,6 +161,7 @@ createPaginator({
   dialect,                              // e.g. new PostgresPaginationDialect()
   cursorCodec?,                         // default SuperJSON → Base64URL
   keysetStrategy?: 'auto' | 'portable', // default 'auto'
+  maxLimit?,                            // optional; limit > maxLimit → INVALID_LIMIT
 }): Paginator  // { paginate, paginateWithEdges }
 ```
 
@@ -188,6 +189,10 @@ await paginator.paginate({
 }
 ```
 
+`hasNextPage` / `hasPrevPage` are independent of whether `nextPage` / `prevPage` are set.
+With pure offset, an empty page at `offset > 0` sets `hasPrevPage: true` without a `prevPage` token —
+step back via offset, not a keyset cursor. Mid-window offset pages may still mint keyset tokens for hybrid continue.
+
 `paginateWithEdges` swaps `items` for `edges: { node: T; cursor: string }[]`.
 
 **Filters** stay on the Kysely query; the paginator only applies order, limit, and the keyset predicate.
@@ -200,7 +205,7 @@ await paginator.paginate({
 | ------------------ | ------------------------------------------------------ |
 | `INVALID_TOKEN`    | Bad/old token, sort signature mismatch, invalid offset |
 | `INVALID_SORT`     | Empty sorts, unsupported `nulls`                       |
-| `INVALID_LIMIT`    | Non-positive limit                                     |
+| `INVALID_LIMIT`    | Non-positive limit, or limit above `maxLimit`          |
 | `UNEXPECTED_ERROR` | Internal / codec failure (`cause`)                     |
 
 Map client mistakes to **400**; `UNEXPECTED_ERROR` to **500**.
@@ -226,6 +231,9 @@ CI runs lint, a Kysely version matrix, and per-dialect benches with regression c
 
 **Why do tokens break when I change sorts?**  
 Tokens hash the sort spec (columns, directions, null placement). A mismatch throws so screens cannot share tokens. Treat decode failures as “start over at page 1.”
+
+**Why is `hasPrevPage` true but `prevPage` missing?**  
+Usually an **offset** request past the end of the result set: no rows, so the library does not invent a keyset prev token, but `offset > 0` means you are not on the first page. Keep the client’s offset and step back (`offset - limit`, clamped to 0), or drop offset and restart with keyset tokens. Do not wire “Back” solely to `prevPage` if you still accept `cursor: { offset }`.
 
 **Deep page still slow on Postgres?**  
 You’re likely still on the null-safe path. Set `notNull: true` on non-null leading keys, match a composite index, keep `keysetStrategy: 'auto'`. See the checklist above and `pnpm bench:postgres`.

--- a/bench/README.md
+++ b/bench/README.md
@@ -22,7 +22,7 @@ await paginator.paginate({ query, sorts, limit, cursor: { offset } })
 
 ## Prerequisites
 
-- Node 24+
+- Node 20+
 - pnpm
 - Docker (for postgres / mysql / mssql)
 

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -4,7 +4,7 @@ A small, runnable tour of [kysely-cursor](../..) against Postgres. It seeds a `p
 
 ## Prerequisites
 
-- Node.js 24+
+- Node.js 20+
 - Docker with Compose v2 (`docker compose`, including `up --wait`)
 - Dependencies from the monorepo root (`pnpm install`)
 

--- a/package.json
+++ b/package.json
@@ -16,11 +16,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
@@ -61,7 +60,7 @@
   "author": "Luke Wood",
   "license": "MIT",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=20.0.0"
   },
   "packageManager": "pnpm@10.18.0",
   "dependencies": {

--- a/src/codec/base64Url.ts
+++ b/src/codec/base64Url.ts
@@ -1,9 +1,18 @@
 import type { Codec } from './codec.js'
 
+/** URL-safe Base64 alphabet (no padding). */
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/
+
 /**
- * Base64 string codec. URL friendly
+ * Base64 string codec. URL friendly (no padding).
+ * Decode rejects empty strings and characters outside the base64url alphabet.
  */
 export const base64UrlCodec: Codec<string, string> = {
   encode: (s) => Buffer.from(s, 'utf8').toString('base64url'),
-  decode: (s) => Buffer.from(s, 'base64url').toString('utf8'),
+  decode: (s) => {
+    if (typeof s !== 'string' || s.length === 0 || !BASE64URL_RE.test(s)) {
+      throw new Error('Invalid base64url payload')
+    }
+    return Buffer.from(s, 'base64url').toString('utf8')
+  },
 }

--- a/src/codec/encrypt.ts
+++ b/src/codec/encrypt.ts
@@ -22,11 +22,11 @@ const scrypt = (secret: string, salt: Buffer): Promise<Buffer> =>
 const concat = (...parts: Buffer[]) => Buffer.concat(parts)
 
 /**
-  * Create a codec that encrypts and decrypts strings using AES-256-GCM.
-  * 
-  * @param secret The secret key used for encryption and decryption. Must be at least 16 characters long.
-  * @returns A codec that can encode and decode strings.
-  * @throws An error if the secret is not a string or is less than 16 characters long.
+ * Create a codec that encrypts and decrypts strings using AES-256-GCM.
+ *
+ * @param secret The secret key used for encryption and decryption. Must be at least 16 characters long.
+ * @returns A codec that can encode and decode strings.
+ * @throws An error if the secret is not a string or is less than 16 characters long.
  */
 export const createAesCodec = (secret: string): Codec<string, string> => {
   if (typeof secret !== 'string' || secret.length < MIN_SECRET_LEN) {

--- a/src/codec/encrypt.ts
+++ b/src/codec/encrypt.ts
@@ -2,90 +2,80 @@ import crypto from 'crypto'
 
 import type { Codec } from './codec.js'
 
+const MIN_SECRET_LEN = 16
+const KEY_LEN = 32
+const IV_LEN = 12
+const TAG_LEN = 16
+const SCRYPT_N = 1 << 15
+const SCRYPT_r = 8
+const SCRYPT_p = 1
+const SCRYPT_OPTS = { N: SCRYPT_N, r: SCRYPT_r, p: SCRYPT_p, maxmem: 256 * 1024 * 1024 } as const
+
+/** AES payload format: fixed key + per-token IV. */
+const VERSION = 2
+
+const scrypt = (secret: string, salt: Buffer): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    crypto.scrypt(secret, salt, KEY_LEN, SCRYPT_OPTS, (err, dk) => (err ? reject(err) : resolve(dk as Buffer)))
+  })
+
+const concat = (...parts: Buffer[]) => Buffer.concat(parts)
+
 /**
- * AES-256-GCM string codec (scrypt-derived key, random salt/IV, versioned payload).
- *
- * ```ts
- * const codec = createAesCodec(process.env.SECRET!)
- * const encrypted = await codec.encode('hello')
- * const decrypted = await codec.decode(encrypted)
- * ```
- *
- * Payload is Base64 of `[1-byte ver][salt][iv][tag][ciphertext]`.
- * Tampering or a wrong secret throws on decode.
+  * Create a codec that encrypts and decrypts strings using AES-256-GCM.
+  * 
+  * @param secret The secret key used for encryption and decryption. Must be at least 16 characters long.
+  * @returns A codec that can encode and decode strings.
+  * @throws An error if the secret is not a string or is less than 16 characters long.
  */
 export const createAesCodec = (secret: string): Codec<string, string> => {
-  const VERSION = Buffer.from([1])
-  const SALT_LEN = 16
-  const IV_LEN = 12
-  const TAG_LEN = 16
-  const KEY_LEN = 32
-  const SCRYPT_N = 1 << 15,
-    SCRYPT_r = 8,
-    SCRYPT_p = 1
+  if (typeof secret !== 'string' || secret.length < MIN_SECRET_LEN) {
+    throw new Error(`AES secret must be a string of at least ${MIN_SECRET_LEN} characters`)
+  }
 
-  const kdf = (salt: Buffer) =>
-    new Promise<Buffer>((resolve, reject) => {
-      crypto.scrypt(
-        secret,
-        salt,
-        KEY_LEN,
-        { N: SCRYPT_N, r: SCRYPT_r, p: SCRYPT_p, maxmem: 256 * 1024 * 1024 },
-        (err, dk) => (err ? reject(err) : resolve(dk as Buffer)),
-      )
-    })
-
-  const concat = (...parts: Buffer[]) => Buffer.concat(parts)
+  // Fixed label salt — key is stable for the life of the codec instance.
+  const fixedSalt = Buffer.from('kysely-cursor-aes-v2', 'utf8')
+  // Lazy so factory stays sync; first encode/decode awaits derivation.
+  let keyPromise: Promise<Buffer> | undefined
+  const getKey = () => {
+    keyPromise ??= scrypt(secret, fixedSalt)
+    return keyPromise
+  }
 
   return {
     encode: async (plain: string): Promise<string> => {
-      const salt = crypto.randomBytes(SALT_LEN)
-      const key = await kdf(salt)
+      const key = await getKey()
       const iv = crypto.randomBytes(IV_LEN)
+      const ver = Buffer.from([VERSION])
 
-      try {
-        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
-        const aad = concat(VERSION, salt)
+      const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+      cipher.setAAD(ver, { plaintextLength: Buffer.byteLength(plain, 'utf8') })
 
-        cipher.setAAD(aad, {
-          plaintextLength: Buffer.byteLength(plain, 'utf8'),
-        })
+      const ciphertext = concat(cipher.update(plain, 'utf8'), cipher.final())
+      const tag = cipher.getAuthTag()
 
-        const ciphertext = concat(cipher.update(plain, 'utf8'), cipher.final())
-        const tag = cipher.getAuthTag()
-
-        return concat(VERSION, salt, iv, tag, ciphertext).toString('base64')
-      } finally {
-        key.fill(0)
-      }
+      return concat(ver, iv, tag, ciphertext).toString('base64')
     },
 
     decode: async (payload: string): Promise<string> => {
       const buf = Buffer.from(payload, 'base64')
-      const HEADER = 1 + SALT_LEN + IV_LEN + TAG_LEN
+      const HEADER = 1 + IV_LEN + TAG_LEN
       if (buf.length < HEADER) throw new Error('Invalid payload: too short')
 
-      const ver = buf.subarray(0, 1)
-      if (ver[0] !== 1) throw new Error(`Unsupported version: ${ver[0]}`)
+      const ver = buf[0]
+      if (ver !== VERSION) throw new Error(`Unsupported version: ${ver}`)
 
-      const salt = buf.subarray(1, 1 + SALT_LEN)
-      const iv = buf.subarray(1 + SALT_LEN, 1 + SALT_LEN + IV_LEN)
-      const tag = buf.subarray(1 + SALT_LEN + IV_LEN, HEADER)
+      const iv = buf.subarray(1, 1 + IV_LEN)
+      const tag = buf.subarray(1 + IV_LEN, HEADER)
       const ciphertext = buf.subarray(HEADER)
 
-      const key = await kdf(salt)
-      try {
-        const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
-        const aad = concat(ver, salt)
+      const key = await getKey()
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+      decipher.setAAD(buf.subarray(0, 1), { plaintextLength: ciphertext.length })
+      decipher.setAuthTag(tag)
 
-        decipher.setAAD(aad, { plaintextLength: ciphertext.length })
-        decipher.setAuthTag(tag)
-
-        const plaintext = concat(decipher.update(ciphertext), decipher.final())
-        return plaintext.toString('utf8')
-      } finally {
-        key.fill(0)
-      }
+      const plaintext = concat(decipher.update(ciphertext), decipher.final())
+      return plaintext.toString('utf8')
     },
   }
 }

--- a/src/codec/stash.ts
+++ b/src/codec/stash.ts
@@ -4,7 +4,11 @@ import type { Codec } from './codec.js'
 
 /** Async string key-value store (in-memory, Redis, filesystem, …). */
 export type Stash = {
-  get: (key: string) => Promise<string>
+  /**
+   * Return the stored value, or `null`/`undefined` when missing.
+   * Missing keys surface as `INVALID_TOKEN` via the cursor codec chain.
+   */
+  get: (key: string) => Promise<string | null | undefined>
   set: (key: string, value: string) => Promise<void>
 }
 
@@ -13,7 +17,11 @@ export type Stash = {
  * Useful for short tokens when payloads are large or sensitive.
  */
 export const stashCodec = (stash: Stash): Codec<string, string> => ({
-  decode: (value) => stash.get(value),
+  decode: async (value) => {
+    const stored = await stash.get(value)
+    if (stored == null) throw new Error('Stash key not found')
+    return stored
+  },
   encode: async (value) => {
     const key = randomUUID()
     await stash.set(key, value)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { base64UrlCodec } from './codec/base64Url.js'
 export type { Codec } from './codec/codec.js'
 export { codecPipe } from './codec/codec.js'
 export { createAesCodec } from './codec/encrypt.js'
+export type { Stash } from './codec/stash.js'
 export { stashCodec } from './codec/stash.js'
 export { superJsonCodec } from './codec/superJson.js'
 
@@ -14,10 +15,18 @@ export { PostgresPaginationDialect } from './dialect/postgres.js'
 export { SqlitePaginationDialect } from './dialect/sqlite.js'
 
 // cursor
-export { buildCursorPredicateRecursive, CursorIncoming, EdgeOutgoing } from './cursor.js'
+export type { CursorIncoming, CursorPayload, EdgeOutgoing } from './cursor.js'
+export { buildCursorPredicateRecursive, CURSOR_VERSION } from './cursor.js'
 
 // error
-export { ErrorCode, PaginationError } from './error.js'
+export type { ErrorCode } from './error.js'
+export { PaginationError } from './error.js'
+
+// keyset
+export { emitKeysetPredicate } from './keyset.js'
+
+// sorting
+export type { NullsDirection, SortItem, SortSet } from './sorting.js'
 
 // paginator
 export { createPaginator, paginate, paginateWithEdges } from './paginator.js'

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -22,8 +22,9 @@ export const paginate = async <DB, TB extends keyof DB, O, S extends SortSet<DB,
   dialect,
   cursorCodec = DEFAULT_CURSOR_CODEC,
   keysetStrategy = 'auto',
+  maxLimit,
 }: PaginateArgs<DB, TB, O, S> & PaginatorOptions): Promise<PaginatedResult<O>> => {
-  assertLimitSorts(limit, sorts)
+  assertLimitSorts(limit, sorts, maxLimit)
 
   try {
     const decodedCursor = cursor ? await decodeCursor(cursor, cursorCodec) : null
@@ -56,13 +57,17 @@ export const paginate = async <DB, TB extends keyof DB, O, S extends SortSet<DB,
       rows.length > limit,
     )
 
+    // Offset past end: no rows and no keyset prev token to invent, but the client
+    // is not on the first page — surface hasPrevPage so UIs can step back via offset.
+    const emptyOffsetPastStart = items.length === 0 && decodedCursor?.type === 'offset' && decodedCursor.offset > 0
+
     return {
       items,
       prevPage,
       nextPage,
       startCursor,
       endCursor,
-      hasPrevPage: !!prevPage,
+      hasPrevPage: !!prevPage || emptyOffsetPastStart,
       hasNextPage: !!nextPage,
     }
   } catch (error) {
@@ -90,9 +95,18 @@ export const paginateWithEdges = async <DB, TB extends keyof DB, O, S extends So
   }
 }
 
-const assertLimitSorts = (limit: number, sorts: readonly unknown[]) => {
+const assertLimitSorts = (limit: number, sorts: readonly unknown[], maxLimit?: number) => {
   if (!(Number.isInteger(limit) && limit > 0))
     throw new PaginationError({ message: 'Invalid page size limit', code: 'INVALID_LIMIT' })
+  if (maxLimit !== undefined) {
+    if (!(Number.isInteger(maxLimit) && maxLimit > 0))
+      throw new PaginationError({ message: 'Invalid maxLimit', code: 'INVALID_LIMIT' })
+    if (limit > maxLimit)
+      throw new PaginationError({
+        message: `Page size limit exceeds maxLimit (${maxLimit})`,
+        code: 'INVALID_LIMIT',
+      })
+  }
   if (!Array.isArray(sorts) || sorts.length < 1)
     throw new PaginationError({ message: 'Cannot paginate without sorting', code: 'INVALID_SORT' })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,11 @@ export type PaginatorOptions = {
    * See {@link KeysetStrategy}.
    */
   keysetStrategy?: KeysetStrategy
+  /**
+   * Optional upper bound on `limit`. When set, `limit > maxLimit` throws `INVALID_LIMIT`.
+   * Default: unlimited (no cap).
+   */
+  maxLimit?: number
 }
 
 export type PaginateArgs<DB, TB extends keyof DB, O, S extends SortSet<DB, TB, O>> = {

--- a/test/codec/all.test.ts
+++ b/test/codec/all.test.ts
@@ -10,9 +10,9 @@ describe('codec chain', () => {
     const codec = codecPipe(
       superJsonCodec,
       base64UrlCodec,
-      createAesCodec('secret'),
+      createAesCodec('test-secret-16ch'),
       stashCodec({
-        get: async (key) => stash.get(key)!,
+        get: async (key) => stash.get(key) ?? null,
         set: async (key, value) => void stash.set(key, value),
       }),
     )

--- a/test/codec/base64.test.ts
+++ b/test/codec/base64.test.ts
@@ -1,12 +1,12 @@
 import { base64UrlCodec } from '~/codec/base64Url.js'
 
 describe('base64UrlCodec', () => {
-  it('encodes a known string to base64', async () => {
+  it('encodes a known string to base64url (no padding)', async () => {
     expect(await base64UrlCodec.encode('hello')).toBe('aGVsbG8')
   })
 
-  it('decodes a known base64 string', async () => {
-    expect(await base64UrlCodec.decode('aGVsbG8=')).toBe('hello')
+  it('decodes a known base64url string', async () => {
+    expect(await base64UrlCodec.decode('aGVsbG8')).toBe('hello')
   })
 
   it('roundtrips unicode strings', async () => {
@@ -16,8 +16,12 @@ describe('base64UrlCodec', () => {
     expect(decoded).toBe(input)
   })
 
-  it('handles empty string', async () => {
-    expect(await base64UrlCodec.encode('')).toBe('')
-    expect(await base64UrlCodec.decode('')).toBe('')
+  it('rejects empty string on decode', () => {
+    expect(() => base64UrlCodec.decode('')).toThrow(/Invalid base64url/)
+  })
+
+  it('rejects non-base64url characters (padding, +/)', () => {
+    expect(() => base64UrlCodec.decode('aGVsbG8=')).toThrow(/Invalid base64url/)
+    expect(() => base64UrlCodec.decode('aG+/')).toThrow(/Invalid base64url/)
   })
 })

--- a/test/codec/encrypt.test.ts
+++ b/test/codec/encrypt.test.ts
@@ -1,8 +1,16 @@
 import { createAesCodec } from '~/codec/encrypt.js'
 
+const SECRET = 'test-secret-16ch' // ≥ 16 chars
+const SECRET_ALT = 'other-secret-16c'
+
 describe('createAesCodec (AES-256-GCM)', () => {
+  it('rejects empty or short secrets', () => {
+    expect(() => createAesCodec('')).toThrow(/at least 16/)
+    expect(() => createAesCodec('short')).toThrow(/at least 16/)
+  })
+
   it('roundtrips plaintext with the same secret', async () => {
-    const codec = createAesCodec('secret')
+    const codec = createAesCodec(SECRET)
     const input = 'hello 世界'
     const encrypted = await codec.encode(input)
     expect(typeof encrypted).toBe('string')
@@ -11,32 +19,41 @@ describe('createAesCodec (AES-256-GCM)', () => {
     expect(decrypted).toBe(input)
   })
 
-  it('produces different ciphertext for the same input (random salt/iv)', async () => {
-    const codec = createAesCodec('secret')
+  it('produces different ciphertext for the same input (random iv)', async () => {
+    const codec = createAesCodec(SECRET)
     const input = 'same input'
     const e1 = await codec.encode(input)
     const e2 = await codec.encode(input)
     expect(e1).not.toBe(e2)
   })
 
+  it('writes version byte 2', async () => {
+    const codec = createAesCodec(SECRET)
+    const payload = Buffer.from(await codec.encode('x'), 'base64')
+    expect(payload[0]).toBe(2)
+  })
+
   it('rejects decode with a wrong secret', async () => {
-    const codec1 = createAesCodec('secret-1')
-    const codec2 = createAesCodec('secret-2')
+    const codec1 = createAesCodec(SECRET)
+    const codec2 = createAesCodec(SECRET_ALT)
     const payload = await codec1.encode('top-secret')
     await expect(codec2.decode(payload)).rejects.toThrow()
   })
 
-  it('rejects unsupported version in payload', async () => {
-    const codec = createAesCodec('secret')
-    const headerOnly = Buffer.alloc(1 + 16 + 12 + 16) // ver + salt + iv + tag
-    headerOnly.writeUInt8(0, 0) // unsupported version 0
-    const payload = headerOnly.toString('base64')
-    await expect(codec.decode(payload)).rejects.toThrow(/Unsupported version/)
+  it('rejects unsupported version in payload (including legacy v1)', async () => {
+    const codec = createAesCodec(SECRET)
+    const headerOnly = Buffer.alloc(1 + 12 + 16) // ver + iv + tag
+    headerOnly.writeUInt8(0, 0)
+    await expect(codec.decode(headerOnly.toString('base64'))).rejects.toThrow(/Unsupported version/)
+
+    headerOnly.writeUInt8(1, 0) // legacy per-token-scrypt format
+    await expect(codec.decode(headerOnly.toString('base64'))).rejects.toThrow(/Unsupported version/)
   })
 
   it('rejects payload that is too short', async () => {
-    const codec = createAesCodec('secret')
-    const tooShort = Buffer.alloc(10).toString('base64')
-    await expect(codec.decode(tooShort)).rejects.toThrow(/Invalid payload: too short/)
+    const codec = createAesCodec(SECRET)
+    const tooShort = Buffer.alloc(10)
+    tooShort.writeUInt8(2, 0)
+    await expect(codec.decode(tooShort.toString('base64'))).rejects.toThrow(/Invalid payload: too short/)
   })
 })

--- a/test/codec/pipe.test.ts
+++ b/test/codec/pipe.test.ts
@@ -88,7 +88,7 @@ describe('codecPipe', () => {
       },
     }
 
-    const pipe = codecPipe(superJsonCodec, base64UrlCodec, createAesCodec('super-secret'), stashCodec(stash))
+    const pipe = codecPipe(superJsonCodec, base64UrlCodec, createAesCodec('super-secret-16x'), stashCodec(stash))
     const data = {
       data: new Date('2024-01-01T00:00:00.000Z'),
       name: 'Alice',

--- a/test/codec/stash.test.ts
+++ b/test/codec/stash.test.ts
@@ -4,11 +4,7 @@ describe('stashCodec', () => {
   it('stores value and returns a uuid key, then retrieves by key', async () => {
     const storage = new Map<string, string>()
     const stash: Stash = {
-      get: async (key) => {
-        const v = storage.get(key)
-        if (v === undefined) throw new Error('not found')
-        return v
-      },
+      get: async (key) => storage.get(key) ?? null,
       set: async (key, value) => {
         storage.set(key, value)
       },
@@ -24,19 +20,24 @@ describe('stashCodec', () => {
     expect(value).toBe('very-secret')
   })
 
-  it('rejects when decoding an unknown key', async () => {
+  it('rejects when decoding an unknown key (null from get)', async () => {
     const storage = new Map<string, string>()
     const stash: Stash = {
-      get: async (key) => {
-        const v = storage.get(key)
-        if (v === undefined) throw new Error('not found')
-        return v
-      },
+      get: async (key) => storage.get(key) ?? null,
       set: async (key, value) => {
         storage.set(key, value)
       },
     }
     const codec = stashCodec(stash)
     await expect(codec.decode('00000000-0000-4000-8000-000000000000')).rejects.toThrow(/not found/i)
+  })
+
+  it('rejects when get returns undefined', async () => {
+    const stash: Stash = {
+      get: async () => undefined,
+      set: async () => {},
+    }
+    const codec = stashCodec(stash)
+    await expect(codec.decode('any-key')).rejects.toThrow(/not found/i)
   })
 })

--- a/test/dialect/shared.ts
+++ b/test/dialect/shared.ts
@@ -1033,7 +1033,7 @@ export const runSharedTests = (
     expect(mid.startCursor).toEqual(expectedMidStart)
     expect(mid.endCursor).toEqual(expectedMidEnd)
 
-    // Offset beyond dataset => empty items, no cursors
+    // Offset beyond dataset => empty items, no keyset tokens; hasPrevPage so clients can step back
     const empty = await paginator.paginate({
       query: baseBuilder(),
       sorts,
@@ -1043,6 +1043,10 @@ export const runSharedTests = (
     expect(empty.items).toHaveLength(0)
     expect(empty.startCursor).toBeUndefined()
     expect(empty.endCursor).toBeUndefined()
+    expect(empty.prevPage).toBeUndefined()
+    expect(empty.nextPage).toBeUndefined()
+    expect(empty.hasPrevPage).toBe(true)
+    expect(empty.hasNextPage).toBe(false)
   })
 
   it('starts mid-way with offset, then continues using cursor tokens', async () => {

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -97,6 +97,37 @@ describe('paginate (runtime)', () => {
     })
     expect(res.items).toEqual([])
     expect(res.nextPage).toBeUndefined()
+    expect(res.hasPrevPage).toBe(false)
+    expect(res.hasNextPage).toBe(false)
+  })
+
+  it('marks hasPrevPage when offset is past the end with no rows', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    const res = await paginate({
+      query: builder,
+      sorts: validSortsQualifiedOnly,
+      limit: 10,
+      cursor: { offset: 100 },
+      dialect: TestDialect,
+    })
+    expect(res.items).toEqual([])
+    expect(res.prevPage).toBeUndefined()
+    expect(res.nextPage).toBeUndefined()
+    expect(res.hasPrevPage).toBe(true)
+    expect(res.hasNextPage).toBe(false)
+  })
+
+  it('does not mark hasPrevPage for offset 0 empty page', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    const res = await paginate({
+      query: builder,
+      sorts: validSortsQualifiedOnly,
+      limit: 10,
+      cursor: { offset: 0 },
+      dialect: TestDialect,
+    })
+    expect(res.items).toEqual([])
+    expect(res.hasPrevPage).toBe(false)
   })
 
   it('throws on empty sorts at runtime', async () => {
@@ -129,6 +160,32 @@ describe('input validation', () => {
         }),
       ).rejects.toMatchObject({ code: 'INVALID_LIMIT', message: 'Invalid page size limit' })
     }
+  })
+
+  it('rejects limit above maxLimit as INVALID_LIMIT', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    await expect(
+      paginate({
+        query: builder,
+        sorts: validSortsQualifiedOnly,
+        limit: 50,
+        dialect: TestDialect,
+        maxLimit: 25,
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_LIMIT', message: /maxLimit \(25\)/ })
+  })
+
+  it('allows limit equal to maxLimit', async () => {
+    const builder = makeBuilder<DB, 'users', UserRow>([])
+    await expect(
+      paginate({
+        query: builder,
+        sorts: validSortsQualifiedOnly,
+        limit: 25,
+        dialect: TestDialect,
+        maxLimit: 25,
+      }),
+    ).resolves.toMatchObject({ items: [] })
   })
 
   it('rejects negative and non-integer offsets as INVALID_TOKEN', async () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   tsconfig: 'tsconfig.build.json',
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   // tsup's DTS rollup still injects baseUrl (deprecated in TS 6, removed in TS 7).
   // Keep the silence here so workspace tsconfig stays valid under native TS 7 / VS Code.
   dts: {


### PR DESCRIPTION
## Summary

- **Packaging:** ESM-only build (drop CJS), `engines` Node ≥ 20, type-only re-exports, and public exports for sort/cursor types, `Stash`, `emitKeysetPredicate`, etc.
- **Pagination:** Empty offset past the end sets `hasPrevPage: true` without inventing a keyset `prevPage`; optional `maxLimit` → `INVALID_LIMIT`.
- **Codecs:** AES derives key once (payload v2 only; 0.1 encrypted tokens no longer decode); `base64UrlCodec` validates alphabet; `Stash.get` may return null.
- **Docs:** Lean README/install notes for ESM, token stability, offset hybrid, stash, and AES secret length; aligned example/bench Node floor.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` (unit + dialect integration + typecheck)
- [x] `pnpm lint` / `pnpm format`
- [ ] CI green on PR